### PR TITLE
revert(docs): remove copyright notice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,18 +653,6 @@ if(WITH_TESTS)
     add_subdirectory (tests)
 endif(WITH_TESTS)
 
-# Write copyright file
-file(WRITE "${CMAKE_BINARY_DIR}/copyright"
-     "Copyright (C) 2015 Travis Nickles <nickles.travis@gmail.com>
-     Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail.com>
-     Copyright (C) 2020 Paweł Kotiuk <kotiuk@zohomail.eu>")
-install(FILES "${CMAKE_BINARY_DIR}/copyright"
-        DESTINATION "share/doc/${CPACK_DEBIAN_PACKAGE_NAME}/"
-        PERMISSIONS
-        OWNER_WRITE OWNER_READ
-        GROUP_READ
-        WORLD_READ)
-
 
 #building package using CPack
 include(InstallRequiredSystemLibraries)


### PR DESCRIPTION
## Proposed changes 

- copyright notice doesn't belong to a cmake file
- it was put to `/usr/share/copyright` before install - resulted in RPM packaging errors
- it was installed to `/usr/share/doc`, but copyright files belong to `/usr/share/licenses`
- there is already copyright notice in code, so it's not necessary

I suggest just removing this - no negative effect - or if you insist, just adding these copyright lines to README and maybe the about window.