### PR TITLE
build: Create copyright file only for deb pacakges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,17 +653,6 @@ if(WITH_TESTS)
     add_subdirectory (tests)
 endif(WITH_TESTS)
 
-# Write copyright file
-file(WRITE "${CMAKE_BINARY_DIR}/copyright"
-     "Copyright (C) 2015 Travis Nickles <nickles.travis@gmail.com>
-     Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail.com>
-     Copyright (C) 2020 Paweł Kotiuk <kotiuk@zohomail.eu>")
-install(FILES "${CMAKE_BINARY_DIR}/copyright"
-        DESTINATION "share/doc/${CPACK_DEBIAN_PACKAGE_NAME}/"
-        PERMISSIONS
-        OWNER_WRITE OWNER_READ
-        GROUP_READ
-        WORLD_READ)
 
 
 #building package using CPack
@@ -699,6 +688,18 @@ It is a new fork of discontinued AntiMicro.")
   
   message("Preparing documentation for DEB package")
   add_custom_target(package_docummentation ALL)
+
+  # Write copyright file
+  file(WRITE "${CMAKE_BINARY_DIR}/copyright"
+       "Copyright (C) 2015 Travis Nickles <nickles.travis@gmail.com>
+       Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail.com>
+       Copyright (C) 2020 Paweł Kotiuk <kotiuk@zohomail.eu>")
+  install(FILES "${CMAKE_BINARY_DIR}/copyright"
+          DESTINATION "share/doc/${CPACK_DEBIAN_PACKAGE_NAME}/"
+          PERMISSIONS
+          OWNER_WRITE OWNER_READ
+          GROUP_READ
+          WORLD_READ)
 
   #Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
   add_custom_command(TARGET package_docummentation PRE_BUILD


### PR DESCRIPTION
Response to: https://github.com/AntiMicroX/antimicrox/pull/30

`/usr/share/doc/pkg/copyright` seems to be recommended only for deb packages, in case of Fedora packages it may break something.