### PR TITLE
fix: Fix converting hash dictionary to random list. issue #6

### DIFF
--- a/src/setnamesdialog.cpp
+++ b/src/setnamesdialog.cpp
@@ -38,11 +38,12 @@ SetNamesDialog::SetNamesDialog(InputDevice *device, QWidget *parent) :
     setAttribute(Qt::WA_DeleteOnClose);
     this->device = device;
 
-    QList<SetJoystick*> joysList = device->getJoystick_sets().values();
-    for (QList<SetJoystick*>::iterator currSetJoy = joysList.begin(); currSetJoy != joysList.end(); currSetJoy++)
+    auto joysList = device->getJoystick_sets();
+
+    for (int i = 0; i < joysList.size(); i++)
     {
-        int i = currSetJoy - joysList.begin();
-        ui->setNamesTableWidget->setItem(i, 0, new QTableWidgetItem((*currSetJoy)->getName()));
+        auto name = joysList[i]->getName();
+        ui->setNamesTableWidget->setItem(i, 0, new QTableWidgetItem(name));
     }
 
     connect(this, &SetNamesDialog::accepted, this, &SetNamesDialog::saveSetNameChanges);
@@ -66,6 +67,7 @@ void SetNamesDialog::saveSetNameChanges()
         QString oldSetNameText = device->getSetJoystick(i)->getName();
 
         if (setNameText != oldSetNameText)
+            qDebug() << "Set number: "  << i << "  Renamed to: " << setNameText;
             device->getSetJoystick(i)->setName(setNameText);
     }
 }


### PR DESCRIPTION
Closes #6 

## Fixes
Method `QList<T> QHash::values() const` was returning list containing sets in random order.

From QHash [docs](https://doc.qt.io/qt-5/qhash.html#values):
> Returns a list containing all the values in the hash, in an **arbitrary** order. If a key is associated with multiple values, all of its values will be in the list, and not just the most recently inserted one.

