### PR TITLE
Fix: Use system icons in common cases to avoid incompatibility issues

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,6 +1,7 @@
 /* antimicrox Gamepad to KB+M event mapper
  * Copyright (C) 2015 Travis Nickles <nickles.travis@gmail.com>
  * Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail.com>
+ * Copyright (C) 2020 Paweł Kotiuk <kotiuk@zohomail.eu>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -134,6 +135,23 @@ void unlockInputDevices()
     qInstallMessageHandler(MessageHandler::myMessageOutput);
 
     sdlWaitMutex.unlock();
+}
+/**
+ * @brief Universal method for loading icons
+ *
+ * @param name - name of used icon
+ * @param fallback_location - location of icon loaded when icon described by name not found
+ * @return QIcon
+ */
+QIcon loadIcon(const QString &name, const QString &fallback_location)
+{
+    qDebug() << " Application theme has icon named: " << name << " " << QIcon::hasThemeIcon(name);
+    QFileInfo f(fallback_location);
+    if (!f.exists())
+    {
+        qWarning() << "file " << fallback_location << " does not exist!";
+    }
+    return QIcon::fromTheme(name, QIcon(fallback_location));
 }
 
 QWaitCondition waitThisOut;

--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,7 @@
 /* antimicrox Gamepad to KB+M event mapper
  * Copyright (C) 2015 Travis Nickles <nickles.travis@gmail.com>
  * Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail>
+ * Copyright (C) 2020 Paweł Kotiuk <kotiuk@zohomail.eu>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +25,7 @@
 #include "mousehelper.h"
 
 #include <QDir>
+#include <QIcon>
 #include <QThread>
 #include <QTranslator>
 #include <QWaitCondition>
@@ -84,6 +86,7 @@ void reloadTranslations(QTranslator *translator, QTranslator *appTranslator, QSt
 void lockInputDevices();
 void unlockInputDevices();
 
+QIcon loadIcon(const QString &name, const QString &fallback_location);
 /*!
  * \brief Returns the "human-readable" name of the given profile.
  */

--- a/src/joytabwidget.cpp
+++ b/src/joytabwidget.cpp
@@ -114,9 +114,7 @@ JoyTabWidget::JoyTabWidget(InputDevice *joystick, AntiMicroSettings *settings, Q
     loadButton->setObjectName(QString::fromUtf8("loadButton"));
     loadButton->setToolTip(tr("Load configuration file."));
     loadButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    qDebug() << " Application theme has icon named document_open: " << QIcon::hasThemeIcon("document_open");
-    loadButton->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("document_open"), QIcon(":/icons/hicolor/16x16/actions/document_open.png")));
+    loadButton->setIcon(PadderCommon::loadIcon("document-open", ":/icons/hicolor/16x16/actions/document_open.png"));
 
     configHorizontalLayout->addWidget(loadButton);
 
@@ -124,16 +122,14 @@ JoyTabWidget::JoyTabWidget(InputDevice *joystick, AntiMicroSettings *settings, Q
     saveButton->setObjectName(QString::fromUtf8("saveButton"));
     saveButton->setToolTip(tr("Save changes to configuration file."));
     saveButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    saveButton->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("document_save"), QIcon(":/icons/hicolor/16x16/actions/document_save.png")));
+    saveButton->setIcon(PadderCommon::loadIcon("document-save", ":/icons/hicolor/16x16/actions/document_save.png"));
     configHorizontalLayout->addWidget(saveButton);
 
     saveAsButton = new QPushButton(tr("Save As"), this);
     saveAsButton->setObjectName(QString::fromUtf8("saveAsButton"));
     saveAsButton->setToolTip(tr("Save changes to a new configuration file."));
     saveAsButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    saveAsButton->setIcon(QIcon::fromTheme(QString::fromUtf8("document_save_as"),
-                                           QIcon(":/icons/hicolor/16x16/actions/document_save_as.png")));
+    saveAsButton->setIcon(PadderCommon::loadIcon("document-save-as", ":/icons/hicolor/16x16/actions/document_save_as.png"));
 
     configHorizontalLayout->addWidget(saveAsButton);
 
@@ -469,8 +465,7 @@ JoyTabWidget::JoyTabWidget(InputDevice *joystick, AntiMicroSettings *settings, Q
     resetButton->setObjectName(QString::fromUtf8("resetButton"));
     resetButton->setToolTip(tr("Revert changes to the configuration. Reload configuration file."));
     resetButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    resetButton->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("document_revert"), QIcon(":/icons/hicolor/16x16/actions/document_revert.png")));
+    resetButton->setIcon(PadderCommon::loadIcon("document-revert", ":/icons/hicolor/16x16/actions/document_revert.png"));
 
     horizontalLayout_3->addWidget(resetButton);
 
@@ -1610,8 +1605,8 @@ void JoyTabWidget::displayProfileEditNotification()
     qInstallMessageHandler(MessageHandler::myMessageOutput);
 
     int currentIndex = configBox->currentIndex();
-    configBox->setItemIcon(
-        currentIndex, QIcon::fromTheme("document_save_as", QIcon(":/icons/hicolor/16x16/actions/document_save_as.png")));
+    configBox->setItemIcon(currentIndex,
+                           PadderCommon::loadIcon("document-save-as", ":/icons/hicolor/16x16/actions/document_save_as.png"));
 
     changedNotSaved = true;
 }

--- a/src/keyboard/virtualkeyboardmousewidget.cpp
+++ b/src/keyboard/virtualkeyboardmousewidget.cpp
@@ -615,8 +615,7 @@ void VirtualKeyboardMouseWidget::setupMouseControlLayout()
     tempVBoxLayout->addSpacerItem(new QSpacerItem(20, 10, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
     mouseSettingsPushButton = new QPushButton(tr("Mouse Settings"), this);
-    mouseSettingsPushButton->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("edit_select"), QIcon(":/icons/hicolor/16x16/actions/edit_select.png")));
+    mouseSettingsPushButton->setIcon(PadderCommon::loadIcon("input-mouse", ":/icons/hicolor/16x16/actions/edit_select.png"));
 
     tempVBoxLayout->addWidget(mouseSettingsPushButton);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,6 +571,7 @@ int main(int argc, char *argv[])
     antimicrox.setQuitOnLastWindowClosed(false);
 
     QStringList appDirsLocations = QStandardPaths::standardLocations(QStandardPaths::DataLocation);
+    appDirsLocations.append(QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation));
     QStringList themePathsTries = QStringList();
 
     QList<QString>::const_iterator i;
@@ -582,12 +583,7 @@ int main(int argc, char *argv[])
     }
 
     QIcon::setThemeSearchPaths(themePathsTries);
-    QIcon::setThemeName("hicolor");
-    bool tr = QIcon::hasThemeIcon("games_config_custom"); // real
-    bool tr2 = QIcon::hasThemeIcon("xxx");                // fake
     qDebug() << "Theme name: " << QIcon::themeName();
-    qDebug() << "has icon theme named games_config_custom: " << tr;
-    qDebug() << "if icon theme always returns true: " << tr2;
 
     importLegacySettingsIfExist();
 

--- a/src/mainsettingsdialog.cpp
+++ b/src/mainsettingsdialog.cpp
@@ -83,10 +83,10 @@ MainSettingsDialog::MainSettingsDialog(AntiMicroSettings *settings, QList<InputD
 #endif
 
     ui->profileOpenDirPushButton->setIcon(
-        QIcon::fromTheme("document_open_folder", QIcon(":/icons/hicolor/16x16/actions/document_open_folder.png")));
+        PadderCommon::loadIcon("document-open", ":/icons/hicolor/16x16/actions/document_open_folder.png"));
 
     ui->logFilePushButton->setIcon(
-        QIcon::fromTheme("document_open_folder", QIcon(":/icons/hicolor/16x16/actions/document_open_folder.png")));
+        PadderCommon::loadIcon("document-open", ":/icons/hicolor/16x16/actions/document_open_folder.png"));
 
     this->settings = settings;
     this->allDefaultProfile = nullptr;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -81,8 +81,7 @@ MainWindow::MainWindow(QMap<SDL_JoystickID, InputDevice *> *joysticks, CommandLi
 {
     ui->setupUi(this);
 
-    setWindowIcon(QIcon::fromTheme(QString::fromUtf8("antimicrox"), QIcon(":/images/antimicrox.png")));
-    (QIcon::fromTheme(QString::fromUtf8("application_exit"), QIcon(":/icons/hicolor/16x16/actions/application_exit.png")));
+    setWindowIcon(PadderCommon::loadIcon("antimicrox", ":/images/antimicrox.png"));
 
     qInstallMessageHandler(MessageHandler::myMessageOutput);
     ui->stackedWidget->setCurrentIndex(0);
@@ -455,27 +454,22 @@ void MainWindow::populateTrayIcon()
     profileActions.clear();
 
     closeAction = new QAction(tr("&Quit"), trayIconMenu);
-    closeAction->setIcon(QIcon::fromTheme(QString::fromUtf8("application_exit"),
-                                          QIcon(":/icons/hicolor/16x16/actions/application_exit.png")));
+    closeAction->setIcon(PadderCommon::loadIcon("application-exit", ":/icons/hicolor/16x16/actions/application_exit.png"));
 
     connect(closeAction, &QAction::triggered, this, &MainWindow::quitProgram, Qt::DirectConnection);
 
     hideAction = new QAction(tr("&Hide"), trayIconMenu);
-    hideAction->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("view_restore"), QIcon(":/icons/hicolor/16x16/actions/view_restore.png")));
+    hideAction->setIcon(PadderCommon::loadIcon("view-restore", ":/icons/hicolor/16x16/actions/view_restore.png"));
 
     connect(hideAction, &QAction::triggered, this, &MainWindow::hideWindow);
 
     restoreAction = new QAction(tr("&Restore"), trayIconMenu);
-    qDebug() << " Application theme has icon named view_fullscreen: " << QIcon::hasThemeIcon("view_fullscreen");
-    restoreAction->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("view_fullscreen"), QIcon(":/icons/hicolor/16x16/actions/view_fullscreen.png")));
+    restoreAction->setIcon(PadderCommon::loadIcon("view-fullscreen", ":/icons/hicolor/16x16/actions/view_fullscreen.png"));
 
     connect(restoreAction, &QAction::triggered, this, &MainWindow::show);
 
     updateJoy = new QAction(tr("&Update Joysticks"), trayIconMenu);
-    updateJoy->setIcon(
-        QIcon::fromTheme(QString::fromUtf8("view_refresh"), QIcon(":/icons/hicolor/16x16/actions/view_refresh.png")));
+    updateJoy->setIcon(PadderCommon::loadIcon("view-refresh", ":/icons/hicolor/16x16/actions/view_refresh.png"));
 
     connect(updateJoy, &QAction::triggered, this, &MainWindow::startJoystickRefresh);
 
@@ -615,8 +609,8 @@ void MainWindow::populateTrayIcon()
                     newaction = new QAction(tr("Open File"), trayIconMenu);
                 }
 
-                newaction->setIcon(QIcon::fromTheme(QString::fromUtf8("document_open"),
-                                                    QIcon(":/icons/hicolor/16x16/actions/document_open.png")));
+                newaction->setIcon(
+                    PadderCommon::loadIcon("document-open", ":/icons/hicolor/16x16/actions/document_open.png"));
 
                 connect(newaction, &QAction::triggered, widget, &JoyTabWidget::openConfigFileDialog);
 
@@ -958,8 +952,8 @@ void MainWindow::joystickTrayShow(QMenu *tempmenu)
 
                 if (widget->getJoystick()->isDeviceEdited())
                 {
-                    action->setIcon(QIcon::fromTheme(QString::fromUtf8("document_save_as"),
-                                                     QIcon(":/icons/hicolor/16x16/actions/document_save_as.png")));
+                    action->setIcon(
+                        PadderCommon::loadIcon("document-save-as", ":/icons/hicolor/16x16/actions/document_save_as.png"));
 
                 } else if (!action->icon().isNull())
                 {
@@ -1426,8 +1420,8 @@ void MainWindow::singleTrayProfileMenuShow()
 
                         if (widget->getJoystick()->isDeviceEdited())
                         {
-                            action->setIcon(QIcon::fromTheme(QString::fromUtf8("document_save_as"),
-                                                             QIcon(":/icons/hicolor/16x16/actions/document_save_as.png")));
+                            action->setIcon(PadderCommon::loadIcon("document-save-as",
+                                                                   ":/icons/hicolor/16x16/actions/document_save_as.png"));
                         } else if (!action->icon().isNull())
                         {
                             action->setIcon(QIcon());


### PR DESCRIPTION
Part of #61 
Fix #56
It should also help with #58 

## Proposed changes 
- Usage of default (provided by system) icons in place of all icons with existing counterparts.