### PR TITLE
style: Use Markdown for changelog

### DIFF
--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -100,7 +100,11 @@ void AboutDialog::fillInfoTextBrowser()
     QTextStream changelogStream(&temp);
     QString changelogText = changelogStream.readAll();
     temp.close();
-    ui->changelogPlainTextEdit->setPlainText(changelogText);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    ui->changelogTextEdit->setMarkdown(changelogText);
+#else
+    ui->changelogTextEdit->setPlainText(changelogText);
+#endif
 }
 
 void AboutDialog::changeEvent(QEvent *event)

--- a/src/aboutdialog.ui
+++ b/src/aboutdialog.ui
@@ -342,7 +342,7 @@ p, li { white-space: pre-wrap; }
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
-        <widget class="QPlainTextEdit" name="changelogPlainTextEdit">
+        <widget class="QTextEdit" name="changelogTextEdit">
          <property name="readOnly">
           <bool>true</bool>
          </property>

--- a/tests/testaboutdialog.cpp
+++ b/tests/testaboutdialog.cpp
@@ -39,8 +39,8 @@ void TestAboutDialog::infoTextBrowserEmpty()
 
 void TestAboutDialog::changelogPlainEmpty()
 {
-    QPlainTextEdit* changelogPlainTextEdit = aboutDialog.findChild<QPlainTextEdit*>("changelogPlainTextEdit");
-    QVERIFY2(!changelogPlainTextEdit->toPlainText().isEmpty(), "changelogPlainTextEdit is empty");
+    QPlainTextEdit* changelogTextEdit = aboutDialog.findChild<QPlainTextEdit*>("changelogTextEdit");
+    QVERIFY2(!changelogTextEdit->toPlainText().isEmpty(), "changelogTextEdit is empty");
 }
 
 void TestAboutDialog::textBrowserDevsEmpty()


### PR DESCRIPTION
Based on idea from: https://github.com/AntiMicroX/antimicrox/pull/83

Could anyone having QT in version at least 5.14 How it looks?

Now changelog should look like this:

![](https://user-images.githubusercontent.com/23086060/99148242-ed154780-2686-11eb-82fc-5114b22c6bfa.png)