### PR TITLE
refactor: clean up CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,44 +22,44 @@ set(QT_REQUIRED_VERSION 5.8)
 set(SDL_REQUIRED_VERSION 2.0.6)
 project(antimicrox)
 
-if (POLICY CMP0071)
+if(POLICY CMP0071)
     cmake_policy(SET CMP0071 NEW)
-endif ()
+endif()
 
-if (UNIX)
+if(UNIX)
     find_package(ECM REQUIRED NO_MODULE)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_DIR})
-endif (UNIX)
+endif(UNIX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" "${CMAKE_ROOT}/Modules")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 
-if (UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+if(UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "force cmake prefix to be set for /usr" FORCE)
-endif (UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+endif(UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 
-if (UNIX)
+if(UNIX)
     include(ECMInstallIcons)
-endif (UNIX)
+endif(UNIX)
 
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 
 
-if (COMPILER_SUPPORTS_CXX11)
-    if (NOT WIN32)
+if(COMPILER_SUPPORTS_CXX11)
+    if(NOT WIN32)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
         #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wstrict-null-sentinel -Wstrict-overflow=5 -Wundef -Wno-unused -std=c++11")
-    else ()
+    else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif ()
-else ()
+    endif()
+else()
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif (COMPILER_SUPPORTS_CXX11)
+endif(COMPILER_SUPPORTS_CXX11)
 
 # The version number.
 set(ANTIMICROX_MAJOR_VERSION 3)
@@ -68,49 +68,49 @@ set(ANTIMICROX_PATCH_VERSION 3)
 
 option(WITH_TESTS "Allow tests for classes" OFF)
 
-if (WITH_TESTS)
+if(WITH_TESTS)
     message("Tests enabled")
-endif (WITH_TESTS)
+endif(WITH_TESTS)
 
-if (UNIX)
+if(UNIX)
     option(WITH_X11 "Compile with support for X11." ON)
     option(WITH_UINPUT "Compile with support for uinput. uinput will be usable to simulate events." ON)
     option(WITH_XTEST "Compile with support for XTest.  XTest will be usable to simulate events." ON)
     option(APPDATA "Build project with AppData file support." ON)
-endif (UNIX)
+endif(UNIX)
 
 option(UPDATE_TRANSLATIONS "Call lupdate to update translation files from source." OFF)
 option(TRANS_KEEP_OBSOLETE "Add -noobsolete option to lupdate command to get rid of old text entries" OFF)
 option(ATTACH_FAKE_CLASSES "Fake classes can be used in application to tests functionalities" OFF)
 
 
-if (UNIX)
+if(UNIX)
     find_package(PkgConfig REQUIRED)
 
     pkg_check_modules(SDL2 REQUIRED sdl2)
 #    find_package(SDL2 REQUIRED) -> will fail on some systems
 
-    if (WITH_X11)
+    if(WITH_X11)
         find_package(X11 REQUIRED)
-    endif (WITH_X11)
+    endif(WITH_X11)
 
-    if (WITH_XTEST AND NOT WITH_X11)
+    if(WITH_XTEST AND NOT WITH_X11)
         set(WITH_XTEST OFF)
         message("Cannot use XTest without X11. Disabling XTest support.")
-    endif (WITH_XTEST AND NOT WITH_X11)
+    endif(WITH_XTEST AND NOT WITH_X11)
 
-    if (WITH_XTEST)
+    if(WITH_XTEST)
         message("XTest support allowed for simulating events.")
-    endif (WITH_XTEST)
+    endif(WITH_XTEST)
 
-    if (WITH_UINPUT)
+    if(WITH_UINPUT)
         message("uinput support allowed for simulating events.")
-    endif (WITH_UINPUT)
+    endif(WITH_UINPUT)
 
-    if (NOT WITH_XTEST AND NOT WITH_UINPUT)
+    if(NOT WITH_XTEST AND NOT WITH_UINPUT)
         message(FATAL_ERROR "No system is defined for simulating events.")
-    endif (NOT WITH_XTEST AND NOT WITH_UINPUT)
-endif (UNIX)
+    endif(NOT WITH_XTEST AND NOT WITH_UINPUT)
+endif(UNIX)
 
 set(antimicrox_MAIN src/main.cpp)
 
@@ -342,7 +342,7 @@ set(antimicrox_HEADERS
         src/xmlconfigwriter.h
         )
 
-if (ATTACH_FAKE_CLASSES)
+if(ATTACH_FAKE_CLASSES)
     LIST(APPEND antimicrox_SOURCES
             src/fakeclasses/xbox360wireless.cpp
             )
@@ -350,7 +350,7 @@ if (ATTACH_FAKE_CLASSES)
     LIST(APPEND antimicrox_HEADERS
             src/fakeclasses/xbox360wireless.h
             )
-endif (ATTACH_FAKE_CLASSES)
+endif(ATTACH_FAKE_CLASSES)
 
 set(antimicrox_FORMS
         src/aboutdialog.ui
@@ -379,8 +379,8 @@ set(antimicrox_FORMS
 set(antimicrox_RESOURCES src/resources.qrc)
 
 # Platform dependent files.
-if (UNIX)
-    if (WITH_X11)
+if(UNIX)
+    if(WITH_X11)
         LIST(APPEND antimicrox_SOURCES src/x11extras.cpp
                 src/qtx11keymapper.cpp
                 src/unixcapturewindowutility.cpp
@@ -396,13 +396,13 @@ if (UNIX)
                 src/qglobalshortcut/qglobalshortcut.h
                 )
 
-        if (WITH_XTEST)
+        if(WITH_XTEST)
             LIST(APPEND antimicrox_SOURCES src/eventhandlers/xtesteventhandler.cpp)
             LIST(APPEND antimicrox_HEADERS src/eventhandlers/xtesteventhandler.h)
-        endif (WITH_XTEST)
-    endif (WITH_X11)
+        endif(WITH_XTEST)
+    endif(WITH_X11)
 
-    if (WITH_UINPUT)
+    if(WITH_UINPUT)
         LIST(APPEND antimicrox_SOURCES src/qtuinputkeymapper.cpp
                 src/uinputhelper.cpp
                 src/eventhandlers/uinputeventhandler.cpp
@@ -411,24 +411,24 @@ if (UNIX)
                 src/uinputhelper.h
                 src/eventhandlers/uinputeventhandler.h
                 )
-    endif (WITH_UINPUT)
-endif (UNIX)
+    endif(WITH_UINPUT)
+endif(UNIX)
 
-if (UNIX)
-    if (WITH_X11)
+if(UNIX)
+    if(WITH_X11)
         add_definitions(-DWITH_X11)
-    endif (WITH_X11)
+    endif(WITH_X11)
 
-    if (WITH_XTEST)
+    if(WITH_XTEST)
         add_definitions(-DWITH_XTEST)
-    endif (WITH_XTEST)
+    endif(WITH_XTEST)
 
-    if (WITH_UINPUT)
+    if(WITH_UINPUT)
         add_definitions(-DWITH_UINPUT)
-    endif (WITH_UINPUT)
-endif (UNIX)
+    endif(WITH_UINPUT)
+endif(UNIX)
 
-if (UNIX)
+if(UNIX)
     find_package(Qt5Widgets ${QT_REQUIRED_VERSION} REQUIRED)
     find_package(Qt5Core ${QT_REQUIRED_VERSION} REQUIRED)
     find_package(Qt5Gui ${QT_REQUIRED_VERSION} REQUIRED)
@@ -437,9 +437,9 @@ if (UNIX)
     find_package(Qt5Concurrent ${QT_REQUIRED_VERSION} REQUIRED)
     #find_package(Qt5Test REQUIRED)
 
-    if (WITH_X11)
+    if(WITH_X11)
         find_package(Qt5X11Extras REQUIRED)
-    endif ()
+    endif()
 
     QT5_WRAP_CPP(antimicrox_HEADERS_MOC ${antimicrox_HEADERS})
     QT5_WRAP_UI(antimicrox_FORMS_HEADERS ${antimicrox_FORMS})
@@ -448,7 +448,7 @@ if (UNIX)
     add_subdirectory("share/antimicrox/translations")
 
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif (UNIX)
+endif(UNIX)
 
 
 # linker libraries
@@ -458,23 +458,23 @@ LIST(APPEND QT_LIBS Qt5::Widgets)
 LIST(APPEND QT_LIBS Qt5::Concurrent)
 LIST(APPEND QT_LIBS Qt5::Network)
 
-if (UNIX)
-    if (WITH_X11)
+if(UNIX)
+    if(WITH_X11)
         LIST(APPEND X11_LIBS ${X11_X11_LIB})
         LIST(APPEND X11_LIBS ${X11_Xi_LIB})
         LIST(APPEND X11_LIBS Qt5::X11Extras)
         LIST(APPEND X11_LIBS xcb)
-    endif (WITH_X11)
+    endif(WITH_X11)
 
-    if (WITH_XTEST)
+    if(WITH_XTEST)
         LIST(APPEND EXTRA_LIBS ${X11_XTest_LIB})
-    endif (WITH_XTEST)
+    endif(WITH_XTEST)
 
-     # necessary if we use find_package for SDL2
+     # necessary ifwe use find_package for SDL2
 #    if(NOT DEFINED SDL2_LIBRARIES)
 #        set(SDL2_LIBRARIES SDL2::SDL2)
-#    endif ()
-endif (UNIX)
+#    endif()
+endif(UNIX)
 
 
 include_directories(
@@ -485,10 +485,10 @@ include_directories(
 )
 
 
-if (UNIX)
+if(UNIX)
     # Store executable in a bin subdir. Needed here so translations can be loaded.
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
-endif (UNIX)
+endif(UNIX)
 
 
 add_executable(antimicrox
@@ -508,13 +508,13 @@ target_link_libraries(antimicrox
 
 
 # Specify out directory for final executable.
-if (UNIX)
+if(UNIX)
     install(TARGETS antimicrox RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     #           install(TARGETS antilib DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     install(FILES ${antimicrox_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/antimicrox")
-endif (UNIX)
+endif(UNIX)
 
-if (UNIX)
+if(UNIX)
     ecm_install_icons(ICONS src/icons/application/16x16/apps/16-apps-io.github.antimicrox.antimicrox.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons)
     ecm_install_icons(ICONS src/icons/application/24x24/apps/24-apps-io.github.antimicrox.antimicrox.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons)
     ecm_install_icons(ICONS src/icons/application/32x32/apps/32-apps-io.github.antimicrox.antimicrox.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons)
@@ -532,20 +532,20 @@ if (UNIX)
 
     # Copy current Changelog file to location that the resource file expects.
     install(FILES CHANGELOG.md DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/antimicrox")
-endif (UNIX)
+endif(UNIX)
 
 # Add man page for *nix platforms.
-if (UNIX)
+if(UNIX)
     add_subdirectory(other)
 
     # Only way to force install target to be dependent on manpage.
     install(CODE "execute_process(COMMAND ${CMAKE_BUILD_TOOL} manpage WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 
-    if (APPDATA)
+    if(APPDATA)
         # Only way to force install target to be dependent on appdata.
         install(CODE "execute_process(COMMAND ${CMAKE_BUILD_TOOL} appdata WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
-    endif (APPDATA)
-endif (UNIX)
+    endif(APPDATA)
+endif(UNIX)
 
 # uninstall target
 configure_file(
@@ -569,10 +569,10 @@ configure_file(
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/)
 
-if (WITH_TESTS)
+if(WITH_TESTS)
     enable_testing()
     add_subdirectory(tests)
-endif (WITH_TESTS)
+endif(WITH_TESTS)
 
 
 #building package using CPack
@@ -592,13 +592,13 @@ set(CPACK_PACKAGE_FILE_NAME "antimicrox-${ANTIMICROX_MAJOR_VERSION}.${ANTIMICROX
 
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "CMake ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}")
 
-if (UNIX)
+if(UNIX)
     set(CPACK_STRIP_FILES "")
     set(CPACK_SOURCE_STRIP_FILES "")
-endif ()
+endif()
 
 # Building .deb package
-if (CPACK_GENERATOR STREQUAL "DEB")
+if(CPACK_GENERATOR STREQUAL "DEB")
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "qtbase5-dev (>= ${QT_REQUIRED_VERSION}), libsdl2-2.0-0 (>= ${SDL_REQUIRED_VERSION}), libqt5x11extras5, libc6")
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "pktiuk <kotiuk@zohomail.eu>")
     set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "AntiMicroX is a graphical program used to map gamepad buttons to keyboard, mouse, scripts and macros.
@@ -616,7 +616,7 @@ It is a new fork of discontinued AntiMicro.")
     #Strip binaries from unnecessary notes, comments, etc
     add_custom_command(TARGET antimicrox POST_BUILD
             COMMAND strip --strip-unneeded --remove-section=.comment --remove-section=.note "${CMAKE_CURRENT_BINARY_DIR}/bin/antimicrox" VERBATIM)
-endif ()
+endif()
 
 set(CPACK_PACKAGE_EXECUTABLES "antimicrox" "antimicrox")
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,46 +22,44 @@ set(QT_REQUIRED_VERSION 5.8)
 set(SDL_REQUIRED_VERSION 2.0.6)
 project(antimicrox)
 
-if(POLICY CMP0071)
-  cmake_policy(SET CMP0071 NEW)
-endif()
+if (POLICY CMP0071)
+    cmake_policy(SET CMP0071 NEW)
+endif ()
 
-if(UNIX)
+if (UNIX)
     find_package(ECM REQUIRED NO_MODULE)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_DIR})
-endif(UNIX)
+endif (UNIX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" "${CMAKE_ROOT}/Modules")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 
-if (UNIX AND NOT APPLE)
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+if (UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "force cmake prefix to be set for /usr" FORCE)
-endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-endif(UNIX AND NOT APPLE)
+endif (UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 
 if (UNIX)
     include(ECMInstallIcons)
-endif(UNIX)
+endif (UNIX)
 
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 
 
-if(COMPILER_SUPPORTS_CXX11)
+if (COMPILER_SUPPORTS_CXX11)
     if (NOT WIN32)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
         #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wstrict-null-sentinel -Wstrict-overflow=5 -Wundef -Wno-unused -std=c++11")
-    else()
+    else ()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
-else()
+    endif ()
+else ()
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif()
+endif (COMPILER_SUPPORTS_CXX11)
 
 # The version number.
 set(ANTIMICROX_MAJOR_VERSION 3)
@@ -70,453 +68,453 @@ set(ANTIMICROX_PATCH_VERSION 3)
 
 option(WITH_TESTS "Allow tests for classes" OFF)
 
-if(WITH_TESTS)
+if (WITH_TESTS)
     message("Tests enabled")
-endif(WITH_TESTS)
+endif (WITH_TESTS)
 
-if(UNIX)
+if (UNIX)
     option(WITH_X11 "Compile with support for X11." ON)
     option(WITH_UINPUT "Compile with support for uinput. uinput will be usable to simulate events." ON)
     option(WITH_XTEST "Compile with support for XTest.  XTest will be usable to simulate events." ON)
     option(APPDATA "Build project with AppData file support." ON)
-endif(UNIX)
+endif (UNIX)
 
 option(UPDATE_TRANSLATIONS "Call lupdate to update translation files from source." OFF)
 option(TRANS_KEEP_OBSOLETE "Add -noobsolete option to lupdate command to get rid of old text entries" OFF)
 option(ATTACH_FAKE_CLASSES "Fake classes can be used in application to tests functionalities" OFF)
 
 
-# Use pkg-config to find SDL library.
-if(UNIX)
+if (UNIX)
     find_package(PkgConfig REQUIRED)
 
     pkg_check_modules(SDL2 REQUIRED sdl2)
+#    find_package(SDL2 REQUIRED) -> will fail on some systems
 
-    if(WITH_X11)
+    if (WITH_X11)
         find_package(X11 REQUIRED)
-    endif(WITH_X11)
+    endif (WITH_X11)
 
-    if(WITH_XTEST AND NOT WITH_X11)
+    if (WITH_XTEST AND NOT WITH_X11)
         set(WITH_XTEST OFF)
         message("Cannot use XTest without X11. Disabling XTest support.")
-    endif(WITH_XTEST AND NOT WITH_X11)
+    endif (WITH_XTEST AND NOT WITH_X11)
 
-    if(WITH_XTEST)
+    if (WITH_XTEST)
         message("XTest support allowed for simulating events.")
-    endif(WITH_XTEST)
+    endif (WITH_XTEST)
 
-    if(WITH_UINPUT)
+    if (WITH_UINPUT)
         message("uinput support allowed for simulating events.")
-    endif(WITH_UINPUT)
+    endif (WITH_UINPUT)
 
-    if(NOT WITH_XTEST AND NOT WITH_UINPUT)
+    if (NOT WITH_XTEST AND NOT WITH_UINPUT)
         message(FATAL_ERROR "No system is defined for simulating events.")
-    endif(NOT WITH_XTEST AND NOT WITH_UINPUT)
-endif(UNIX)
+    endif (NOT WITH_XTEST AND NOT WITH_UINPUT)
+endif (UNIX)
 
-set(antimicrox_MAIN
-    src/main.cpp
-    )
+set(antimicrox_MAIN src/main.cpp)
 
 set(antimicrox_SOURCES
-    src/aboutdialog.cpp
-    src/addeditautoprofiledialog.cpp
-    src/advancebuttondialog.cpp
-    src/advancestickassignmentdialog.cpp
-    src/antimicrosettings.cpp
-    src/antkeymapper.cpp
-    src/applaunchhelper.cpp
-    src/autoprofileinfo.cpp
-    src/axiseditdialog.cpp
-    src/axisvaluebox.cpp
-    src/buttoneditdialog.cpp
-    src/calibration.cpp
-    src/commandlineutility.cpp
-    src/common.cpp
-    src/dpadcontextmenu.cpp
-    src/dpadeditdialog.cpp
-    src/dpadpushbutton.cpp
-    src/dpadpushbuttongroup.cpp
-    src/editalldefaultautoprofiledialog.cpp
-    src/event.cpp
-    src/eventhandlerfactory.cpp
-    src/eventhandlers/baseeventhandler.cpp
-    src/extraprofilesettingsdialog.cpp
-    src/flashbuttonwidget.cpp
-    src/gamecontroller/gamecontroller.cpp
-    src/gamecontroller/gamecontrollerdpad.cpp
-    src/gamecontroller/gamecontrollerset.cpp
-    src/gamecontroller/gamecontrollertrigger.cpp
-    src/gamecontroller/gamecontrollertriggerbutton.cpp
-    src/gamecontroller/xml/gamecontrollerdpadxml.cpp
-    src/gamecontroller/xml/gamecontrollertriggerxml.cpp
-    src/gamecontroller/xml/gamecontrollerxml.cpp
-    src/gamecontrollerexample.cpp
-    src/gamecontrollermappingdialog.cpp
-    src/globalvariables.cpp
-    src/inputdaemon.cpp
-    src/inputdevice.cpp
-    src/inputdevicebitarraystatus.cpp
-    src/joyaxis.cpp
-    src/joyaxiscontextmenu.cpp
-    src/joyaxiswidget.cpp
-    src/joybutton.cpp
-    src/joybuttoncontextmenu.cpp
-    src/joybuttonmousehelper.cpp
-    src/joybuttonslot.cpp
-    src/joybuttonstatusbox.cpp
-    src/joybuttontypes/joyaxisbutton.cpp
-    src/joybuttontypes/joycontrolstickbutton.cpp
-    src/joybuttontypes/joycontrolstickmodifierbutton.cpp
-    src/joybuttontypes/joydpadbutton.cpp
-    src/joybuttontypes/joygradientbutton.cpp
-    src/joybuttonwidget.cpp
-    src/joycontrolstick.cpp
-    src/joycontrolstickbuttonpushbutton.cpp
-    src/joycontrolstickcontextmenu.cpp
-    src/joycontrolstickeditdialog.cpp
-    src/joycontrolstickpushbutton.cpp
-    src/joycontrolstickstatusbox.cpp
-    src/joydpad.cpp
-    src/joydpadbuttonwidget.cpp
-    src/joystick.cpp
-    src/joystickstatuswindow.cpp
-    src/joytabwidget.cpp
-    src/joytabwidgetcontainer.cpp
-    src/keyboard/virtualkeyboardmousewidget.cpp
-    src/keyboard/virtualkeypushbutton.cpp
-    src/keyboard/virtualmousepushbutton.cpp
-    src/localantimicroserver.cpp
-    src/logger.cpp
-    src/mainsettingsdialog.cpp
-    src/mainwindow.cpp
-    src/messagehandler.cpp
-    src/mousedialog/mouseaxissettingsdialog.cpp
-    src/mousedialog/mousebuttonsettingsdialog.cpp
-    src/mousedialog/mousecontrolsticksettingsdialog.cpp
-    src/mousedialog/mousedpadsettingsdialog.cpp
-    src/mousedialog/springmoderegionpreview.cpp
-    src/mousedialog/uihelpers/mouseaxissettingsdialoghelper.cpp
-    src/mousedialog/uihelpers/mousebuttonsettingsdialoghelper.cpp
-    src/mousedialog/uihelpers/mousecontrolsticksettingsdialoghelper.cpp
-    src/mousedialog/uihelpers/mousedpadsettingsdialoghelper.cpp
-    src/mousehelper.cpp
-    src/mousesettingsdialog.cpp
-    src/qkeydisplaydialog.cpp
-    src/qtkeymapperbase.cpp
-    src/quicksetdialog.cpp
-    src/sdleventreader.cpp
-    src/setaxisthrottledialog.cpp
-    src/setjoystick.cpp
-    src/setnamesdialog.cpp
-    src/simplekeygrabberbutton.cpp
-    src/slotitemlistwidget.cpp
-    src/stickpushbuttongroup.cpp
-    src/uihelpers/advancebuttondialoghelper.cpp
-    src/uihelpers/buttoneditdialoghelper.cpp
-    src/uihelpers/dpadcontextmenuhelper.cpp
-    src/uihelpers/dpadeditdialoghelper.cpp
-    src/uihelpers/gamecontrollermappingdialoghelper.cpp
-    src/uihelpers/joyaxiscontextmenuhelper.cpp
-    src/uihelpers/joycontrolstickcontextmenuhelper.cpp
-    src/uihelpers/joycontrolstickeditdialoghelper.cpp
-    src/uihelpers/joytabwidgethelper.cpp
-    src/vdpad.cpp
-    src/xml/inputdevicexml.cpp
-    src/xml/joyaxisxml.cpp
-    src/xml/joybuttonslotxml.cpp
-    src/xml/joybuttonxml.cpp
-    src/xml/joydpadxml.cpp
-    src/xml/setjoystickxml.cpp
-    src/xmlconfigmigration.cpp
-    src/xmlconfigreader.cpp
-    src/xmlconfigwriter.cpp
-)
+        src/aboutdialog.cpp
+        src/addeditautoprofiledialog.cpp
+        src/advancebuttondialog.cpp
+        src/advancestickassignmentdialog.cpp
+        src/antimicrosettings.cpp
+        src/antkeymapper.cpp
+        src/applaunchhelper.cpp
+        src/autoprofileinfo.cpp
+        src/axiseditdialog.cpp
+        src/axisvaluebox.cpp
+        src/buttoneditdialog.cpp
+        src/calibration.cpp
+        src/commandlineutility.cpp
+        src/common.cpp
+        src/dpadcontextmenu.cpp
+        src/dpadeditdialog.cpp
+        src/dpadpushbutton.cpp
+        src/dpadpushbuttongroup.cpp
+        src/editalldefaultautoprofiledialog.cpp
+        src/event.cpp
+        src/eventhandlerfactory.cpp
+        src/eventhandlers/baseeventhandler.cpp
+        src/extraprofilesettingsdialog.cpp
+        src/flashbuttonwidget.cpp
+        src/gamecontroller/gamecontroller.cpp
+        src/gamecontroller/gamecontrollerdpad.cpp
+        src/gamecontroller/gamecontrollerset.cpp
+        src/gamecontroller/gamecontrollertrigger.cpp
+        src/gamecontroller/gamecontrollertriggerbutton.cpp
+        src/gamecontroller/xml/gamecontrollerdpadxml.cpp
+        src/gamecontroller/xml/gamecontrollertriggerxml.cpp
+        src/gamecontroller/xml/gamecontrollerxml.cpp
+        src/gamecontrollerexample.cpp
+        src/gamecontrollermappingdialog.cpp
+        src/globalvariables.cpp
+        src/inputdaemon.cpp
+        src/inputdevice.cpp
+        src/inputdevicebitarraystatus.cpp
+        src/joyaxis.cpp
+        src/joyaxiscontextmenu.cpp
+        src/joyaxiswidget.cpp
+        src/joybutton.cpp
+        src/joybuttoncontextmenu.cpp
+        src/joybuttonmousehelper.cpp
+        src/joybuttonslot.cpp
+        src/joybuttonstatusbox.cpp
+        src/joybuttontypes/joyaxisbutton.cpp
+        src/joybuttontypes/joycontrolstickbutton.cpp
+        src/joybuttontypes/joycontrolstickmodifierbutton.cpp
+        src/joybuttontypes/joydpadbutton.cpp
+        src/joybuttontypes/joygradientbutton.cpp
+        src/joybuttonwidget.cpp
+        src/joycontrolstick.cpp
+        src/joycontrolstickbuttonpushbutton.cpp
+        src/joycontrolstickcontextmenu.cpp
+        src/joycontrolstickeditdialog.cpp
+        src/joycontrolstickpushbutton.cpp
+        src/joycontrolstickstatusbox.cpp
+        src/joydpad.cpp
+        src/joydpadbuttonwidget.cpp
+        src/joystick.cpp
+        src/joystickstatuswindow.cpp
+        src/joytabwidget.cpp
+        src/joytabwidgetcontainer.cpp
+        src/keyboard/virtualkeyboardmousewidget.cpp
+        src/keyboard/virtualkeypushbutton.cpp
+        src/keyboard/virtualmousepushbutton.cpp
+        src/localantimicroserver.cpp
+        src/logger.cpp
+        src/mainsettingsdialog.cpp
+        src/mainwindow.cpp
+        src/messagehandler.cpp
+        src/mousedialog/mouseaxissettingsdialog.cpp
+        src/mousedialog/mousebuttonsettingsdialog.cpp
+        src/mousedialog/mousecontrolsticksettingsdialog.cpp
+        src/mousedialog/mousedpadsettingsdialog.cpp
+        src/mousedialog/springmoderegionpreview.cpp
+        src/mousedialog/uihelpers/mouseaxissettingsdialoghelper.cpp
+        src/mousedialog/uihelpers/mousebuttonsettingsdialoghelper.cpp
+        src/mousedialog/uihelpers/mousecontrolsticksettingsdialoghelper.cpp
+        src/mousedialog/uihelpers/mousedpadsettingsdialoghelper.cpp
+        src/mousehelper.cpp
+        src/mousesettingsdialog.cpp
+        src/qkeydisplaydialog.cpp
+        src/qtkeymapperbase.cpp
+        src/quicksetdialog.cpp
+        src/sdleventreader.cpp
+        src/setaxisthrottledialog.cpp
+        src/setjoystick.cpp
+        src/setnamesdialog.cpp
+        src/simplekeygrabberbutton.cpp
+        src/slotitemlistwidget.cpp
+        src/stickpushbuttongroup.cpp
+        src/uihelpers/advancebuttondialoghelper.cpp
+        src/uihelpers/buttoneditdialoghelper.cpp
+        src/uihelpers/dpadcontextmenuhelper.cpp
+        src/uihelpers/dpadeditdialoghelper.cpp
+        src/uihelpers/gamecontrollermappingdialoghelper.cpp
+        src/uihelpers/joyaxiscontextmenuhelper.cpp
+        src/uihelpers/joycontrolstickcontextmenuhelper.cpp
+        src/uihelpers/joycontrolstickeditdialoghelper.cpp
+        src/uihelpers/joytabwidgethelper.cpp
+        src/vdpad.cpp
+        src/xml/inputdevicexml.cpp
+        src/xml/joyaxisxml.cpp
+        src/xml/joybuttonslotxml.cpp
+        src/xml/joybuttonxml.cpp
+        src/xml/joydpadxml.cpp
+        src/xml/setjoystickxml.cpp
+        src/xmlconfigmigration.cpp
+        src/xmlconfigreader.cpp
+        src/xmlconfigwriter.cpp
+        )
 
 set(antimicrox_HEADERS
-    src/aboutdialog.h
-    src/addeditautoprofiledialog.h
-    src/advancebuttondialog.h
-    src/advancestickassignmentdialog.h
-    src/antimicrosettings.h
-    src/antkeymapper.h
-    src/applaunchhelper.h
-    src/autoprofileinfo.h
-    src/axiseditdialog.h
-    src/axisvaluebox.h
-    src/buttoneditdialog.h
-    src/calibration.h
-    src/commandlineutility.h
-    src/dpadcontextmenu.h
-    src/dpadeditdialog.h
-    src/dpadpushbutton.h
-    src/dpadpushbuttongroup.h
-    src/editalldefaultautoprofiledialog.h
-    src/eventhandlerfactory.h
-    src/eventhandlers/baseeventhandler.h
-    src/extraprofilesettingsdialog.h
-    src/flashbuttonwidget.h
-    src/gamecontroller/gamecontroller.h
-    src/gamecontroller/gamecontrollerdpad.h
-    src/gamecontroller/gamecontrollerset.h
-    src/gamecontroller/gamecontrollertrigger.h
-    src/gamecontroller/gamecontrollertriggerbutton.h
-    src/gamecontroller/xml/gamecontrollerdpadxml.h
-    src/gamecontroller/xml/gamecontrollertriggerxml.h
-    src/gamecontroller/xml/gamecontrollerxml.h
-    src/gamecontrollerexample.h
-    src/gamecontrollermappingdialog.h
-    src/globalvariables.h
-    src/inputdaemon.h
-    src/inputdevice.h
-    src/inputdevicebitarraystatus.h
-    src/joyaxis.h
-    src/joyaxiscontextmenu.h
-    src/joyaxiswidget.h
-    src/joybutton.h
-    src/joybuttoncontextmenu.h
-    src/joybuttonmousehelper.h
-    src/joybuttonslot.h
-    src/joybuttonstatusbox.h
-    src/joybuttontypes/joyaxisbutton.h
-    src/joybuttontypes/joycontrolstickbutton.h
-    src/joybuttontypes/joycontrolstickmodifierbutton.h
-    src/joybuttontypes/joydpadbutton.h
-    src/joybuttontypes/joygradientbutton.h
-    src/joybuttonwidget.h
-    src/joycontrolstick.h
-    src/joycontrolstickbuttonpushbutton.h
-    src/joycontrolstickcontextmenu.h
-    src/joycontrolstickeditdialog.h
-    src/joycontrolstickpushbutton.h
-    src/joycontrolstickstatusbox.h
-    src/joydpad.h
-    src/joydpadbuttonwidget.h
-    src/joystick.h
-    src/joystickstatuswindow.h
-    src/joytabwidget.h
-    src/joytabwidgetcontainer.h
-    src/keyboard/virtualkeyboardmousewidget.h
-    src/keyboard/virtualkeypushbutton.h
-    src/keyboard/virtualmousepushbutton.h
-    src/localantimicroserver.h
-    src/logger.h
-    src/mainsettingsdialog.h
-    src/mainwindow.h
-    src/messagehandler.h
-    src/mousedialog/mouseaxissettingsdialog.h
-    src/mousedialog/mousebuttonsettingsdialog.h
-    src/mousedialog/mousecontrolsticksettingsdialog.h
-    src/mousedialog/mousedpadsettingsdialog.h
-    src/mousedialog/springmoderegionpreview.h
-    src/mousedialog/uihelpers/mouseaxissettingsdialoghelper.h
-    src/mousedialog/uihelpers/mousebuttonsettingsdialoghelper.h
-    src/mousedialog/uihelpers/mousecontrolsticksettingsdialoghelper.h
-    src/mousedialog/uihelpers/mousedpadsettingsdialoghelper.h
-    src/mousehelper.h
-    src/mousesettingsdialog.h
-    src/qkeydisplaydialog.h
-    src/qtkeymapperbase.h
-    src/quicksetdialog.h
-    src/sdleventreader.h
-    src/setaxisthrottledialog.h
-    src/setjoystick.h
-    src/setnamesdialog.h
-    src/simplekeygrabberbutton.h
-    src/slotitemlistwidget.h
-    src/stickpushbuttongroup.h
-    src/uihelpers/advancebuttondialoghelper.h
-    src/uihelpers/buttoneditdialoghelper.h
-    src/uihelpers/dpadcontextmenuhelper.h
-    src/uihelpers/dpadeditdialoghelper.h
-    src/uihelpers/gamecontrollermappingdialoghelper.h
-    src/uihelpers/joyaxiscontextmenuhelper.h
-    src/uihelpers/joycontrolstickcontextmenuhelper.h
-    src/uihelpers/joycontrolstickeditdialoghelper.h
-    src/uihelpers/joytabwidgethelper.h
-    src/vdpad.h
-    src/xml/inputdevicexml.h
-    src/xml/joyaxisxml.h
-    src/xml/joybuttonslotxml.h
-    src/xml/joybuttonxml.h
-    src/xml/joydpadxml.h
-    src/xml/setjoystickxml.h
-    src/xmlconfigmigration.h
-    src/xmlconfigreader.h
-    src/xmlconfigwriter.h
-)
+        src/aboutdialog.h
+        src/addeditautoprofiledialog.h
+        src/advancebuttondialog.h
+        src/advancestickassignmentdialog.h
+        src/antimicrosettings.h
+        src/antkeymapper.h
+        src/applaunchhelper.h
+        src/autoprofileinfo.h
+        src/axiseditdialog.h
+        src/axisvaluebox.h
+        src/buttoneditdialog.h
+        src/calibration.h
+        src/commandlineutility.h
+        src/dpadcontextmenu.h
+        src/dpadeditdialog.h
+        src/dpadpushbutton.h
+        src/dpadpushbuttongroup.h
+        src/editalldefaultautoprofiledialog.h
+        src/eventhandlerfactory.h
+        src/eventhandlers/baseeventhandler.h
+        src/extraprofilesettingsdialog.h
+        src/flashbuttonwidget.h
+        src/gamecontroller/gamecontroller.h
+        src/gamecontroller/gamecontrollerdpad.h
+        src/gamecontroller/gamecontrollerset.h
+        src/gamecontroller/gamecontrollertrigger.h
+        src/gamecontroller/gamecontrollertriggerbutton.h
+        src/gamecontroller/xml/gamecontrollerdpadxml.h
+        src/gamecontroller/xml/gamecontrollertriggerxml.h
+        src/gamecontroller/xml/gamecontrollerxml.h
+        src/gamecontrollerexample.h
+        src/gamecontrollermappingdialog.h
+        src/globalvariables.h
+        src/inputdaemon.h
+        src/inputdevice.h
+        src/inputdevicebitarraystatus.h
+        src/joyaxis.h
+        src/joyaxiscontextmenu.h
+        src/joyaxiswidget.h
+        src/joybutton.h
+        src/joybuttoncontextmenu.h
+        src/joybuttonmousehelper.h
+        src/joybuttonslot.h
+        src/joybuttonstatusbox.h
+        src/joybuttontypes/joyaxisbutton.h
+        src/joybuttontypes/joycontrolstickbutton.h
+        src/joybuttontypes/joycontrolstickmodifierbutton.h
+        src/joybuttontypes/joydpadbutton.h
+        src/joybuttontypes/joygradientbutton.h
+        src/joybuttonwidget.h
+        src/joycontrolstick.h
+        src/joycontrolstickbuttonpushbutton.h
+        src/joycontrolstickcontextmenu.h
+        src/joycontrolstickeditdialog.h
+        src/joycontrolstickpushbutton.h
+        src/joycontrolstickstatusbox.h
+        src/joydpad.h
+        src/joydpadbuttonwidget.h
+        src/joystick.h
+        src/joystickstatuswindow.h
+        src/joytabwidget.h
+        src/joytabwidgetcontainer.h
+        src/keyboard/virtualkeyboardmousewidget.h
+        src/keyboard/virtualkeypushbutton.h
+        src/keyboard/virtualmousepushbutton.h
+        src/localantimicroserver.h
+        src/logger.h
+        src/mainsettingsdialog.h
+        src/mainwindow.h
+        src/messagehandler.h
+        src/mousedialog/mouseaxissettingsdialog.h
+        src/mousedialog/mousebuttonsettingsdialog.h
+        src/mousedialog/mousecontrolsticksettingsdialog.h
+        src/mousedialog/mousedpadsettingsdialog.h
+        src/mousedialog/springmoderegionpreview.h
+        src/mousedialog/uihelpers/mouseaxissettingsdialoghelper.h
+        src/mousedialog/uihelpers/mousebuttonsettingsdialoghelper.h
+        src/mousedialog/uihelpers/mousecontrolsticksettingsdialoghelper.h
+        src/mousedialog/uihelpers/mousedpadsettingsdialoghelper.h
+        src/mousehelper.h
+        src/mousesettingsdialog.h
+        src/qkeydisplaydialog.h
+        src/qtkeymapperbase.h
+        src/quicksetdialog.h
+        src/sdleventreader.h
+        src/setaxisthrottledialog.h
+        src/setjoystick.h
+        src/setnamesdialog.h
+        src/simplekeygrabberbutton.h
+        src/slotitemlistwidget.h
+        src/stickpushbuttongroup.h
+        src/uihelpers/advancebuttondialoghelper.h
+        src/uihelpers/buttoneditdialoghelper.h
+        src/uihelpers/dpadcontextmenuhelper.h
+        src/uihelpers/dpadeditdialoghelper.h
+        src/uihelpers/gamecontrollermappingdialoghelper.h
+        src/uihelpers/joyaxiscontextmenuhelper.h
+        src/uihelpers/joycontrolstickcontextmenuhelper.h
+        src/uihelpers/joycontrolstickeditdialoghelper.h
+        src/uihelpers/joytabwidgethelper.h
+        src/vdpad.h
+        src/xml/inputdevicexml.h
+        src/xml/joyaxisxml.h
+        src/xml/joybuttonslotxml.h
+        src/xml/joybuttonxml.h
+        src/xml/joydpadxml.h
+        src/xml/setjoystickxml.h
+        src/xmlconfigmigration.h
+        src/xmlconfigreader.h
+        src/xmlconfigwriter.h
+        )
 
-if(ATTACH_FAKE_CLASSES)
+if (ATTACH_FAKE_CLASSES)
     LIST(APPEND antimicrox_SOURCES
-        src/fakeclasses/xbox360wireless.cpp
-    )
+            src/fakeclasses/xbox360wireless.cpp
+            )
 
     LIST(APPEND antimicrox_HEADERS
-        src/fakeclasses/xbox360wireless.h
-        )
-endif(ATTACH_FAKE_CLASSES)
+            src/fakeclasses/xbox360wireless.h
+            )
+endif (ATTACH_FAKE_CLASSES)
 
 set(antimicrox_FORMS
-    src/aboutdialog.ui
-    src/addeditautoprofiledialog.ui
-    src/advancebuttondialog.ui
-    src/advancestickassignmentdialog.ui
-    src/axiseditdialog.ui
-    src/buttoneditdialog.ui
-    src/calibration.ui
-    src/capturedwindowinfodialog.ui
-    src/dpadeditdialog.ui
-    src/editalldefaultautoprofiledialog.ui
-    src/extraprofilesettingsdialog.ui
-    src/gamecontrollermappingdialog.ui
-    src/joycontrolstickeditdialog.ui
-    src/joystickstatuswindow.ui
-    src/mainsettingsdialog.ui
-    src/mainwindow.ui
-    src/mousesettingsdialog.ui
-    src/qkeydisplaydialog.ui
-    src/quicksetdialog.ui
-    src/setaxisthrottledialog.ui
-    src/setnamesdialog.ui
-)
+        src/aboutdialog.ui
+        src/addeditautoprofiledialog.ui
+        src/advancebuttondialog.ui
+        src/advancestickassignmentdialog.ui
+        src/axiseditdialog.ui
+        src/buttoneditdialog.ui
+        src/calibration.ui
+        src/capturedwindowinfodialog.ui
+        src/dpadeditdialog.ui
+        src/editalldefaultautoprofiledialog.ui
+        src/extraprofilesettingsdialog.ui
+        src/gamecontrollermappingdialog.ui
+        src/joycontrolstickeditdialog.ui
+        src/joystickstatuswindow.ui
+        src/mainsettingsdialog.ui
+        src/mainwindow.ui
+        src/mousesettingsdialog.ui
+        src/qkeydisplaydialog.ui
+        src/quicksetdialog.ui
+        src/setaxisthrottledialog.ui
+        src/setnamesdialog.ui
+        )
 
 set(antimicrox_RESOURCES src/resources.qrc)
 
 # Platform dependent files.
-if(UNIX)
-    if(WITH_X11)
+if (UNIX)
+    if (WITH_X11)
         LIST(APPEND antimicrox_SOURCES src/x11extras.cpp
-             src/qtx11keymapper.cpp
-             src/unixcapturewindowutility.cpp
-             src/autoprofilewatcher.cpp
-             src/capturedwindowinfodialog.cpp
-             src/qglobalshortcut/qglobalshortcut.cc
-        )
+                src/qtx11keymapper.cpp
+                src/unixcapturewindowutility.cpp
+                src/autoprofilewatcher.cpp
+                src/capturedwindowinfodialog.cpp
+                src/qglobalshortcut/qglobalshortcut.cc
+                )
         LIST(APPEND antimicrox_HEADERS src/x11extras.h
-             src/qtx11keymapper.h
-             src/unixcapturewindowutility.h
-             src/autoprofilewatcher.h
-             src/capturedwindowinfodialog.h
-             src/qglobalshortcut/qglobalshortcut.h
-        )
+                src/qtx11keymapper.h
+                src/unixcapturewindowutility.h
+                src/autoprofilewatcher.h
+                src/capturedwindowinfodialog.h
+                src/qglobalshortcut/qglobalshortcut.h
+                )
 
-        if(WITH_XTEST)
+        if (WITH_XTEST)
             LIST(APPEND antimicrox_SOURCES src/eventhandlers/xtesteventhandler.cpp)
             LIST(APPEND antimicrox_HEADERS src/eventhandlers/xtesteventhandler.h)
-        endif(WITH_XTEST)
-    endif(WITH_X11)
+        endif (WITH_XTEST)
+    endif (WITH_X11)
 
-    if(WITH_UINPUT)
+    if (WITH_UINPUT)
         LIST(APPEND antimicrox_SOURCES src/qtuinputkeymapper.cpp
-             src/uinputhelper.cpp
-             src/eventhandlers/uinputeventhandler.cpp
-        )
+                src/uinputhelper.cpp
+                src/eventhandlers/uinputeventhandler.cpp
+                )
         LIST(APPEND antimicrox_HEADERS src/qtuinputkeymapper.h
-             src/uinputhelper.h
-             src/eventhandlers/uinputeventhandler.h
-        )
-    endif(WITH_UINPUT)
-endif(UNIX)
-
-if(UNIX)
-    if(WITH_X11)
-        add_definitions(-DWITH_X11)
-    endif(WITH_X11)
-
-    if(WITH_XTEST)
-        add_definitions(-DWITH_XTEST)
-    endif(WITH_XTEST)
-
-    if(WITH_UINPUT)
-        add_definitions(-DWITH_UINPUT)
-    endif(WITH_UINPUT)
-endif(UNIX)
+                src/uinputhelper.h
+                src/eventhandlers/uinputeventhandler.h
+                )
+    endif (WITH_UINPUT)
+endif (UNIX)
 
 if (UNIX)
+    if (WITH_X11)
+        add_definitions(-DWITH_X11)
+    endif (WITH_X11)
 
-        find_package(Qt5Widgets ${QT_REQUIRED_VERSION}  REQUIRED)
-        find_package(Qt5Core ${QT_REQUIRED_VERSION}  REQUIRED)
-        find_package(Qt5Gui ${QT_REQUIRED_VERSION}  REQUIRED)
-        find_package(Qt5Network ${QT_REQUIRED_VERSION}  REQUIRED)
-        find_package(Qt5LinguistTools ${QT_REQUIRED_VERSION}  REQUIRED)
-        find_package(Qt5Concurrent ${QT_REQUIRED_VERSION}  REQUIRED)
-        #find_package(Qt5Test REQUIRED)
+    if (WITH_XTEST)
+        add_definitions(-DWITH_XTEST)
+    endif (WITH_XTEST)
 
-        if (WITH_X11)
-            find_package(Qt5X11Extras REQUIRED)
-        endif()
+    if (WITH_UINPUT)
+        add_definitions(-DWITH_UINPUT)
+    endif (WITH_UINPUT)
+endif (UNIX)
 
-        QT5_WRAP_CPP(antimicrox_HEADERS_MOC ${antimicrox_HEADERS})
-        QT5_WRAP_UI(antimicrox_FORMS_HEADERS ${antimicrox_FORMS})
-        QT5_ADD_RESOURCES(antimicrox_RESOURCES_RCC ${antimicrox_RESOURCES})
+if (UNIX)
+    find_package(Qt5Widgets ${QT_REQUIRED_VERSION} REQUIRED)
+    find_package(Qt5Core ${QT_REQUIRED_VERSION} REQUIRED)
+    find_package(Qt5Gui ${QT_REQUIRED_VERSION} REQUIRED)
+    find_package(Qt5Network ${QT_REQUIRED_VERSION} REQUIRED)
+    find_package(Qt5LinguistTools ${QT_REQUIRED_VERSION} REQUIRED)
+    find_package(Qt5Concurrent ${QT_REQUIRED_VERSION} REQUIRED)
+    #find_package(Qt5Test REQUIRED)
 
-        add_subdirectory("share/antimicrox/translations")
+    if (WITH_X11)
+        find_package(Qt5X11Extras REQUIRED)
+    endif ()
 
-        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif(UNIX)
+    QT5_WRAP_CPP(antimicrox_HEADERS_MOC ${antimicrox_HEADERS})
+    QT5_WRAP_UI(antimicrox_FORMS_HEADERS ${antimicrox_FORMS})
+    QT5_ADD_RESOURCES(antimicrox_RESOURCES_RCC ${antimicrox_RESOURCES})
 
-if(UNIX)
-    if(WITH_X11)
-        LIST(APPEND LIBS ${X11_X11_LIB})
-        LIST(APPEND LIBS ${X11_Xi_LIB})
-    endif(WITH_X11)
+    add_subdirectory("share/antimicrox/translations")
 
-    if(WITH_XTEST)
-        LIST(APPEND LIBS ${X11_XTest_LIB})
-    endif(WITH_XTEST)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif (UNIX)
 
-   list(APPEND LIBS ${SDL2_LIBRARIES})
 
+# linker libraries
+LIST(APPEND QT_LIBS Qt5::Core)
+LIST(APPEND QT_LIBS Qt5::Gui)
+LIST(APPEND QT_LIBS Qt5::Widgets)
+LIST(APPEND QT_LIBS Qt5::Concurrent)
+LIST(APPEND QT_LIBS Qt5::Network)
+
+if (UNIX)
+    if (WITH_X11)
+        LIST(APPEND X11_LIBS ${X11_X11_LIB})
+        LIST(APPEND X11_LIBS ${X11_Xi_LIB})
+        LIST(APPEND X11_LIBS Qt5::X11Extras)
+        LIST(APPEND X11_LIBS xcb)
+    endif (WITH_X11)
+
+    if (WITH_XTEST)
+        LIST(APPEND EXTRA_LIBS ${X11_XTest_LIB})
+    endif (WITH_XTEST)
+
+     # necessary if we use find_package for SDL2
+#    if(NOT DEFINED SDL2_LIBRARIES)
+#        set(SDL2_LIBRARIES SDL2::SDL2)
+#    endif ()
 endif (UNIX)
 
 
 include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR}
-    "${CMAKE_CURRENT_BINARY_DIR}/src"
-    ${PROJECT_SOURCE_DIR}
-    "${PROJECT_SOURCE_DIR}/src"
-    )
+        ${CMAKE_CURRENT_BINARY_DIR}
+        "${CMAKE_CURRENT_BINARY_DIR}/src"
+        ${PROJECT_SOURCE_DIR}
+        "${PROJECT_SOURCE_DIR}/src"
+)
 
 
-if(UNIX)
+if (UNIX)
     # Store executable in a bin subdir. Needed here so translations can be loaded.
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
-endif(UNIX)
-
+endif (UNIX)
 
 
 add_executable(antimicrox
-    ${antimicrox_MAIN}
-    ${antimicrox_HEADERS_MOC}
-    ${antimicrox_SOURCES}
-    ${antimicrox_FORMS_HEADERS}
-    ${antimicrox_RESOURCES_RCC}
-    )
+        ${antimicrox_MAIN}
+        ${antimicrox_HEADERS_MOC}
+        ${antimicrox_SOURCES}
+        ${antimicrox_FORMS_HEADERS}
+        ${antimicrox_RESOURCES_RCC}
+        )
 
-target_link_libraries (antimicrox
-    Qt5::Widgets
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Network
-    Qt5::Concurrent
-    ${SDL_LIBRARY}
-    ${LIBS}
-    xcb
-    )
-
-if(UNIX)
-    target_link_libraries (antimicrox Qt5::X11Extras)
-endif(UNIX)
+target_link_libraries(antimicrox
+        ${QT_LIBS}
+        ${X11_LIBS}
+        ${SDL2_LIBRARIES}
+        ${EXTRA_LIBS}
+        )
 
 
 # Specify out directory for final executable.
-if(UNIX)
-        install(TARGETS antimicrox RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-#           install(TARGETS antilib DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-        install(FILES ${antimicrox_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/antimicrox")
-endif(UNIX)
+if (UNIX)
+    install(TARGETS antimicrox RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    #           install(TARGETS antilib DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    install(FILES ${antimicrox_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/antimicrox")
+endif (UNIX)
 
-if(UNIX)
+if (UNIX)
     ecm_install_icons(ICONS src/icons/application/16x16/apps/16-apps-io.github.antimicrox.antimicrox.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons)
     ecm_install_icons(ICONS src/icons/application/24x24/apps/24-apps-io.github.antimicrox.antimicrox.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons)
     ecm_install_icons(ICONS src/icons/application/32x32/apps/32-apps-io.github.antimicrox.antimicrox.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons)
@@ -534,29 +532,29 @@ if(UNIX)
 
     # Copy current Changelog file to location that the resource file expects.
     install(FILES CHANGELOG.md DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/antimicrox")
-endif(UNIX)
+endif (UNIX)
 
 # Add man page for *nix platforms.
-if(UNIX)
+if (UNIX)
     add_subdirectory(other)
 
     # Only way to force install target to be dependent on manpage.
     install(CODE "execute_process(COMMAND ${CMAKE_BUILD_TOOL} manpage WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 
-    if(APPDATA)
+    if (APPDATA)
         # Only way to force install target to be dependent on appdata.
         install(CODE "execute_process(COMMAND ${CMAKE_BUILD_TOOL} appdata WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
-    endif(APPDATA)
-endif(UNIX)
+    endif (APPDATA)
+endif (UNIX)
 
 # uninstall target
 configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY)
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
 
 add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
 
 # Only way to force install target to be dependent on updateqm.
@@ -565,16 +563,16 @@ install(CODE "execute_process(COMMAND ${CMAKE_BUILD_TOOL} updateqm WORKING_DIREC
 # Use this to use some variables created here in the actual project.
 # Modify the config.h.in file using the appropriate variables.
 configure_file(
-    "${PROJECT_SOURCE_DIR}/src/config.h.in"
-    "${PROJECT_BINARY_DIR}/config.h"
+        "${PROJECT_SOURCE_DIR}/src/config.h.in"
+        "${PROJECT_BINARY_DIR}/config.h"
 )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/)
 
-if(WITH_TESTS)
-    enable_testing ()
-    add_subdirectory (tests)
-endif(WITH_TESTS)
+if (WITH_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif (WITH_TESTS)
 
 
 #building package using CPack
@@ -594,32 +592,31 @@ set(CPACK_PACKAGE_FILE_NAME "antimicrox-${ANTIMICROX_MAJOR_VERSION}.${ANTIMICROX
 
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "CMake ${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}")
 
-if(UNIX)
-  set(CPACK_STRIP_FILES "")
-  set(CPACK_SOURCE_STRIP_FILES "")
-  endif()
+if (UNIX)
+    set(CPACK_STRIP_FILES "")
+    set(CPACK_SOURCE_STRIP_FILES "")
+endif ()
 
 # Building .deb package
-if(CPACK_GENERATOR STREQUAL "DEB")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "qtbase5-dev (>= ${QT_REQUIRED_VERSION}), libsdl2-2.0-0 (>= ${SDL_REQUIRED_VERSION}), libqt5x11extras5, libc6")
-  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "pktiuk <kotiuk@zohomail.eu>")
-  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "AntiMicroX is a graphical program used to map gamepad buttons to keyboard, mouse, scripts and macros.
+if (CPACK_GENERATOR STREQUAL "DEB")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "qtbase5-dev (>= ${QT_REQUIRED_VERSION}), libsdl2-2.0-0 (>= ${SDL_REQUIRED_VERSION}), libqt5x11extras5, libc6")
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "pktiuk <kotiuk@zohomail.eu>")
+    set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "AntiMicroX is a graphical program used to map gamepad buttons to keyboard, mouse, scripts and macros.
 
 It is a new fork of discontinued AntiMicro.")
 
-  message("Preparing documentation for DEB package")
-  add_custom_target(package_docummentation ALL)
+    message("Preparing documentation for DEB package")
+    add_custom_target(package_docummentation ALL)
 
-  #Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
-  add_custom_command(TARGET package_docummentation PRE_BUILD
-  COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/CHANGELOG.md" > "changelog.Debian.gz" VERBATIM)
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.Debian.gz" DESTINATION "share/doc/antimicrox/")
+    #Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
+    add_custom_command(TARGET package_docummentation PRE_BUILD
+            COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/CHANGELOG.md" > "changelog.Debian.gz" VERBATIM)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.Debian.gz" DESTINATION "share/doc/antimicrox/")
 
-  #Strip binaries from unnecessary notes, comments, etc
-  add_custom_command(TARGET antimicrox POST_BUILD
-  COMMAND strip --strip-unneeded --remove-section=.comment --remove-section=.note "${CMAKE_CURRENT_BINARY_DIR}/bin/antimicrox" VERBATIM)
-
-endif()
+    #Strip binaries from unnecessary notes, comments, etc
+    add_custom_command(TARGET antimicrox POST_BUILD
+            COMMAND strip --strip-unneeded --remove-section=.comment --remove-section=.note "${CMAKE_CURRENT_BINARY_DIR}/bin/antimicrox" VERBATIM)
+endif ()
 
 set(CPACK_PACKAGE_EXECUTABLES "antimicrox" "antimicrox")
 include(CPack)

--- a/other/CMakeLists.txt
+++ b/other/CMakeLists.txt
@@ -2,6 +2,6 @@ add_subdirectory(appdata)
 
 add_custom_target(manpage)
 add_custom_command(TARGET manpage PRE_BUILD
-    COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/other/antimicrox.1" > "antimicrox.1.gz" VERBATIM
-)
+        COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/other/antimicrox.1" > "antimicrox.1.gz" VERBATIM
+        )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/antimicrox.1.gz" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/man/man1")

--- a/other/appdata/CMakeLists.txt
+++ b/other/appdata/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Make appdata optional when installing an application.
-if (APPDATA)
+if(APPDATA)
     add_custom_target(appdata)
 
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/PO_files/")
@@ -11,6 +11,6 @@ if (APPDATA)
             COMMAND itstool -i "${PROJECT_SOURCE_DIR}/other/appdata/appdata.its" -j "${PROJECT_SOURCE_DIR}/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in" -o "io.github.antimicrox.antimicrox.appdata.xml" "${CMAKE_CURRENT_BINARY_DIR}/PO_files/*.mo"
             )
 
-    # Only install an appdata file if the user requested to have one built.
+    # Only install an appdata file ifthe user requested to have one built.
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/io.github.antimicrox.antimicrox.appdata.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
-endif (APPDATA)
+endif(APPDATA)

--- a/other/appdata/CMakeLists.txt
+++ b/other/appdata/CMakeLists.txt
@@ -1,16 +1,16 @@
 # Make appdata optional when installing an application.
-if(APPDATA)
+if (APPDATA)
     add_custom_target(appdata)
-    
+
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/PO_files/")
 
     add_custom_command(TARGET appdata PRE_BUILD
-        # Add an entry per language
-        COMMAND msgfmt "${PROJECT_SOURCE_DIR}/other/appdata/PO_files/en.po" -o "${CMAKE_CURRENT_BINARY_DIR}/PO_files/en.mo"
+            # Add an entry per language
+            COMMAND msgfmt "${PROJECT_SOURCE_DIR}/other/appdata/PO_files/en.po" -o "${CMAKE_CURRENT_BINARY_DIR}/PO_files/en.mo"
 
-        COMMAND itstool -i "${PROJECT_SOURCE_DIR}/other/appdata/appdata.its" -j "${PROJECT_SOURCE_DIR}/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in" -o "io.github.antimicrox.antimicrox.appdata.xml" "${CMAKE_CURRENT_BINARY_DIR}/PO_files/*.mo"
-    )
+            COMMAND itstool -i "${PROJECT_SOURCE_DIR}/other/appdata/appdata.its" -j "${PROJECT_SOURCE_DIR}/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in" -o "io.github.antimicrox.antimicrox.appdata.xml" "${CMAKE_CURRENT_BINARY_DIR}/PO_files/*.mo"
+            )
 
     # Only install an appdata file if the user requested to have one built.
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/io.github.antimicrox.antimicrox.appdata.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
-endif(APPDATA)
+endif (APPDATA)

--- a/share/antimicrox/translations/CMakeLists.txt
+++ b/share/antimicrox/translations/CMakeLists.txt
@@ -6,19 +6,19 @@ file(GLOB_RECURSE antimicrox_BASE_SOURCES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE antimicrox_BASE_FORMS ${PROJECT_SOURCE_DIR}/src/*.ui)
 
 
-    if(UPDATE_TRANSLATIONS)
-        message("Update translations - lupdate ON")
-        if(TRANS_KEEP_OBSOLETE)
-            message("getting rid of old text entries: \"lupdate -noobsolete\" ON")
-            QT5_CREATE_TRANSLATION(antimicrox_QMFILES ${antimicrox_BASE_SOURCES}
-            ${antimicrox_BASE_FORMS} ${antimicrox_TRANSLATIONS} OPTIONS -Inobsolete)
-        else()
-            QT5_CREATE_TRANSLATION(antimicrox_QMFILES ${antimicrox_BASE_SOURCES}
-            ${antimicrox_BASE_FORMS} ${antimicrox_TRANSLATIONS})
-        endif(TRANS_KEEP_OBSOLETE)
-    else()
-        QT5_ADD_TRANSLATION(antimicrox_QMFILES ${antimicrox_TRANSLATIONS})
-    endif(UPDATE_TRANSLATIONS)
+if (UPDATE_TRANSLATIONS)
+    message("Update translations - lupdate ON")
+    if (TRANS_KEEP_OBSOLETE)
+        message("getting rid of old text entries: \"lupdate -noobsolete\" ON")
+        QT5_CREATE_TRANSLATION(antimicrox_QMFILES ${antimicrox_BASE_SOURCES}
+                ${antimicrox_BASE_FORMS} ${antimicrox_TRANSLATIONS} OPTIONS -Inobsolete)
+    else ()
+        QT5_CREATE_TRANSLATION(antimicrox_QMFILES ${antimicrox_BASE_SOURCES}
+                ${antimicrox_BASE_FORMS} ${antimicrox_TRANSLATIONS})
+    endif (TRANS_KEEP_OBSOLETE)
+else ()
+    QT5_ADD_TRANSLATION(antimicrox_QMFILES ${antimicrox_TRANSLATIONS})
+endif (UPDATE_TRANSLATIONS)
 
 
 add_custom_target(updateqm DEPENDS ${antimicrox_QMFILES})

--- a/share/antimicrox/translations/CMakeLists.txt
+++ b/share/antimicrox/translations/CMakeLists.txt
@@ -6,19 +6,19 @@ file(GLOB_RECURSE antimicrox_BASE_SOURCES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE antimicrox_BASE_FORMS ${PROJECT_SOURCE_DIR}/src/*.ui)
 
 
-if (UPDATE_TRANSLATIONS)
+if(UPDATE_TRANSLATIONS)
     message("Update translations - lupdate ON")
-    if (TRANS_KEEP_OBSOLETE)
+    if(TRANS_KEEP_OBSOLETE)
         message("getting rid of old text entries: \"lupdate -noobsolete\" ON")
         QT5_CREATE_TRANSLATION(antimicrox_QMFILES ${antimicrox_BASE_SOURCES}
                 ${antimicrox_BASE_FORMS} ${antimicrox_TRANSLATIONS} OPTIONS -Inobsolete)
-    else ()
+    else()
         QT5_CREATE_TRANSLATION(antimicrox_QMFILES ${antimicrox_BASE_SOURCES}
                 ${antimicrox_BASE_FORMS} ${antimicrox_TRANSLATIONS})
-    endif (TRANS_KEEP_OBSOLETE)
-else ()
+    endif(TRANS_KEEP_OBSOLETE)
+else()
     QT5_ADD_TRANSLATION(antimicrox_QMFILES ${antimicrox_TRANSLATIONS})
-endif (UPDATE_TRANSLATIONS)
+endif(UPDATE_TRANSLATIONS)
 
 
 add_custom_target(updateqm DEPENDS ${antimicrox_QMFILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,15 +10,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(Qt5Test REQUIRED)
 
-set( GUIS_SRCS testaboutdialog.cpp
-    testaddeditautoprofiledialog.cpp
-    testadvancebuttondialog.cpp
-    testcalibration.cpp
-    testjoycontrolstickeditdialog.cpp
-    testbuttoneditdialog.cpp
-    testquicksetdialog.cpp
-    testqkeydisplaydialog.cpp
-    )
-add_executable( GuiTests ${GUIS_SRCS} )
+set(GUIS_SRCS testaboutdialog.cpp
+        testaddeditautoprofiledialog.cpp
+        testadvancebuttondialog.cpp
+        testcalibration.cpp
+        testjoycontrolstickeditdialog.cpp
+        testbuttoneditdialog.cpp
+        testquicksetdialog.cpp
+        testqkeydisplaydialog.cpp
+        )
+add_executable(GuiTests ${GUIS_SRCS})
 #target_link_libraries( GuiTests antilib Qt5::Test )
-ADD_TEST( NAME GuiTests COMMAND GuiTests )
+ADD_TEST(NAME GuiTests COMMAND GuiTests)


### PR DESCRIPTION
1- reformated them using CLion 
2- cleaned up some redundant code too.

and 
`find_package(SDL2 REQUIRED)` won't work on all systems, so I added it as a comment.
and the fix will be:
```
    # necessary if we use find_package for SDL2
    if(NOT DEFINED SDL2_LIBRARIES)
        set(SDL2_LIBRARIES SDL2::SDL2)
    endif ()
```