### PR TITLE
Rename changelog for deb packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,8 +610,8 @@ It is a new fork of discontinued AntiMicro.")
 
     #Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
     add_custom_command(TARGET package_docummentation PRE_BUILD
-            COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/CHANGELOG.md" > "changelog.Debian.gz" VERBATIM)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.Debian.gz" DESTINATION "share/doc/antimicrox/")
+            COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/CHANGELOG.md" > "changelog.gz" VERBATIM)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.gz" DESTINATION "share/doc/antimicrox/")
 
     #Strip binaries from unnecessary notes, comments, etc
     add_custom_command(TARGET antimicrox POST_BUILD


### PR DESCRIPTION
According to lintian this should be fixed:

```
E: antimicrox: no-copyright-file
W: antimicrox: desktop-mime-but-no-exec-code usr/share/applications/io.github.antimicrox.antimicrox.desktop
W: antimicrox: extended-description-line-too-long
W: antimicrox: non-standard-dir-perm usr/ 0775 != 0755
W: antimicrox: non-standard-dir-perm usr/bin/ 0775 != 0755
W: antimicrox: non-standard-dir-perm usr/include/ 0775 != 0755
W: antimicrox: non-standard-dir-perm ... use --no-tag-display-limit to see all (or pipe to a file/program)
W: antimicrox: syntax-error-in-debian-changelog line 10 "badly formatted heading line"
W: antimicrox: syntax-error-in-debian-changelog line 102 "badly formatted heading line"
W: antimicrox: syntax-error-in-debian-changelog line 108 "badly formatted heading line"
W: antimicrox: syntax-error-in-debian-changelog ... use --no-tag-display-limit to see all (or pipe to a file/program)
W: antimicrox: wrong-name-for-changelog-of-native-package usr/share/doc/antimicrox/changelog.Debian.gz
N: Interrupted.
```

Report from lintian after this commit:

```
E: antimicrox: no-copyright-file
W: antimicrox: desktop-mime-but-no-exec-code usr/share/applications/io.github.antimicrox.antimicrox.desktop
W: antimicrox: extended-description-line-too-long
W: antimicrox: non-standard-dir-perm usr/ 0775 != 0755
W: antimicrox: non-standard-dir-perm usr/bin/ 0775 != 0755
W: antimicrox: non-standard-dir-perm usr/include/ 0775 != 0755
W: antimicrox: non-standard-dir-perm ... use --no-tag-display-limit to see all (or pipe to a file/program)
```