### PR TITLE
feat: antimicro config migration

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -50,6 +50,15 @@ inline QString configLegacyFilePath()
     return QString(configPath).append("/").append("antimicroX_settings.ini");
 }
 
+inline QString configAntimicroLegacyFilePath()
+{
+    QString configPath = (!qgetenv("XDG_CONFIG_HOME").isEmpty())
+                             ? QString::fromUtf8(qgetenv("XDG_CONFIG_HOME")) + "/antimicro"
+                             : QDir::homePath() + "/.config/antimicro";
+
+    return QString(configPath).append("/").append("antimicro_settings.ini");
+}
+
 const int LATESTCONFIGFILEVERSION = 19;
 // Specify the last known profile version that requires a migration
 // to be performed in order to be compatible with the latest version.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,20 +126,18 @@ void importLegacySettingsIfExist()
         const QFileInfo fileToCopy = legacyConfigExists ? legacyConfig : legacyAntimicroConfig;
         const bool copySuccess = QFile::copy(fileToCopy.canonicalFilePath(), PadderCommon::configFilePath());
         qDebug() << "Legacy settings found";
-        const QString successMessage = QString(
-                "Your original settings (previously stored in %1) "
-                "have been copied to "
-                "~/.config/antimicrox to ensure consistent naming across "
-                "entire project.\nIf you want you can "
-                "delete the original directory or leave it as it is."
-            ).arg(fileToCopy.canonicalFilePath());
-        const QString errorMessage = QString(
-                "Some problem with settings migration occurred.\nOriginal "
-                "configs are stored in %1 "
-                "but their new location is ~/.config/antimicrox.\n"
-                "You can migrate manually by renaming old directory and "
-                "renaming file to antimicrox_settings.ini."
-            ).arg(fileToCopy.canonicalFilePath());
+        const QString successMessage = QString("Your original settings (previously stored in %1) "
+                                               "have been copied to "
+                                               "~/.config/antimicrox to ensure consistent naming across "
+                                               "entire project.\nIf you want you can "
+                                               "delete the original directory or leave it as it is.")
+                                           .arg(fileToCopy.canonicalFilePath());
+        const QString errorMessage = QString("Some problem with settings migration occurred.\nOriginal "
+                                             "configs are stored in %1 "
+                                             "but their new location is ~/.config/antimicrox.\n"
+                                             "You can migrate manually by renaming old directory and "
+                                             "renaming file to antimicrox_settings.ini.")
+                                         .arg(fileToCopy.canonicalFilePath());
 
         QMessageBox msgBox;
         if (copySuccess)
@@ -148,9 +146,8 @@ void importLegacySettingsIfExist()
             msgBox.setText(successMessage);
         } else
         {
-            qDebug() << "Problem with importing settings from: "
-                << fileToCopy.canonicalFilePath()
-                << " to: " << PadderCommon::configFilePath();
+            qDebug() << "Problem with importing settings from: " << fileToCopy.canonicalFilePath()
+                     << " to: " << PadderCommon::configFilePath();
             msgBox.setText(errorMessage);
         }
         msgBox.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,7 +146,7 @@ void importLegacySettingsIfExist()
             msgBox.setText(successMessage);
         } else
         {
-            qDebug() << "Problem with importing settings from: " << fileToCopy.canonicalFilePath()
+            qWarning() << "Problem with importing settings from: " << fileToCopy.canonicalFilePath()
                      << " to: " << PadderCommon::configFilePath();
             msgBox.setText(errorMessage);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,7 @@ void importLegacySettingsIfExist()
         } else
         {
             qWarning() << "Problem with importing settings from: " << fileToCopy.canonicalFilePath()
-                     << " to: " << PadderCommon::configFilePath();
+                       << " to: " << PadderCommon::configFilePath();
             msgBox.setText(errorMessage);
         }
         msgBox.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,44 +105,55 @@ static void deleteInputDevices(QMap<SDL_JoystickID, InputDevice *> *joysticks)
 }
 
 /**
- * @brief Function used for copying settings used by previous revisions of
- * antimicrox to provide backward compatibility
- * TODO remove it later
+ * @brief Function used for copying settings used by antimicro and
+ * previous revisions of antimicrox to provide backward compatibility
  */
 void importLegacySettingsIfExist()
 {
     qDebug() << "Importing settings";
-    QFileInfo current(PadderCommon::configFilePath());
-    QFileInfo legacy(PadderCommon::configLegacyFilePath());
-    if (legacy.exists() && legacy.isFile())
+    const QFileInfo config(PadderCommon::configFilePath());
+    const bool configExists = config.exists() && config.isFile();
+    // 'antimicroX'
+    const QFileInfo legacyConfig(PadderCommon::configLegacyFilePath());
+    const bool legacyConfigExists = legacyConfig.exists() && legacyConfig.isFile();
+    // 'antimicro'
+    const QFileInfo legacyAntimicroConfig(PadderCommon::configAntimicroLegacyFilePath());
+    const bool legacyAntimicroConfigExists = legacyAntimicroConfig.exists() && legacyAntimicroConfig.isFile();
+
+    const bool requireMigration = !configExists && (legacyConfigExists || legacyAntimicroConfigExists);
+    if (requireMigration)
     {
+        const QFileInfo fileToCopy = legacyConfigExists ? legacyConfig : legacyAntimicroConfig;
+        const bool copySuccess = QFile::copy(fileToCopy.canonicalFilePath(), PadderCommon::configFilePath());
         qDebug() << "Legacy settings found";
-        if (!current.exists())
+        const QString successMessage = QString(
+                "Your original settings (previously stored in %1) "
+                "have been copied to "
+                "~/.config/antimicrox to ensure consistent naming across "
+                "entire project.\nIf you want you can "
+                "delete the original directory or leave it as it is."
+            ).arg(fileToCopy.canonicalFilePath());
+        const QString errorMessage = QString(
+                "Some problem with settings migration occurred.\nOriginal "
+                "configs are stored in %1 "
+                "but their new location is ~/.config/antimicrox.\n"
+                "You can migrate manually by renaming old directory and "
+                "renaming file to antimicrox_settings.ini."
+            ).arg(fileToCopy.canonicalFilePath());
+
+        QMessageBox msgBox;
+        if (copySuccess)
         {
-            if (QFile::copy(PadderCommon::configLegacyFilePath(), PadderCommon::configFilePath()))
-            {
-                qDebug() << "Legacy antimicroX settings copied";
-                QMessageBox msgBox;
-                msgBox.setText("Your original settings (previously stored in "
-                               "~/.config/antimicroX) have been copied to "
-                               "~/.config/antimicrox to ensure consistent naming across "
-                               "entire project, if you want you can "
-                               "delete original directory or leave it as it is");
-                msgBox.exec();
-            } else
-            {
-                qDebug() << "Problem with importing antimicroX settings from: " << PadderCommon::configLegacyFilePath()
-                         << " to: " << PadderCommon::configFilePath();
-                QMessageBox msgBox;
-                msgBox.setText("Some problem with settings migration occurred.\nOriginal "
-                               "configs are stored in ~/.config/antimicroX, "
-                               "but their new location is ~/.config/antimicrox\nYou can "
-                               "do it manually by renaming old directory and "
-                               "renaming file antimicroX_settings.ini to "
-                               "antimicrox_settings.ini");
-                msgBox.exec();
-            }
+            qDebug() << "Legacy settings copied";
+            msgBox.setText(successMessage);
+        } else
+        {
+            qDebug() << "Problem with importing settings from: "
+                << fileToCopy.canonicalFilePath()
+                << " to: " << PadderCommon::configFilePath();
+            msgBox.setText(errorMessage);
         }
+        msgBox.exec();
     }
 }
 


### PR DESCRIPTION
Closes #86 

## Proposed changes 

- clean up migration logic a bit
- add `antimicro` migration
- `antimicro` takes priority over `antimicroX` (it's unlikely that a user will have both)

----


<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

