### PR TITLE
feat: improve mime type definition

### DIFF
--- a/other/io.github.antimicrox.antimicrox.xml
+++ b/other/io.github.antimicrox.antimicrox.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-amgp">
-    <comment xml:lang="en">AntiMicroX Profile</comment>
+    <comment>AntiMicroX profile</comment>
+    <sub-class-of type="application/xml"/>
     <glob pattern="*.amgp"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
## Proposed changes 

- Remove the `xml:lang` attribute from the `<comment>` element, as it causes systems to not display *any* comment in locales other than “en”, which is worse that displaying a generic english comment in such locales.
- Make `application/x-amgp` a subclass of `application/xml` so it is automatically associated with XML editors and the `application-xml` icon.