### PR TITLE
make it possible to build reproducibly

### DIFF
--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -60,7 +60,11 @@ void AboutDialog::fillInfoTextBrowser()
     QStringList finalInfoText = QStringList();
 
     finalInfoText.append(tr("Program Version %1").arg(PadderCommon::programVersion));
+#ifdef ANTIMICROX_PKG_VERSION
+    finalInfoText.append(tr("compiled from packaging: %1").arg(ANTIMICROX_PKG_VERSION));
+#else
     finalInfoText.append(tr("Program Compiled on %1 at %2").arg(__DATE__).arg(__TIME__));
+#endif
 
     QString sdlCompiledVersionNumber("%1.%2.%3");
     QString sdlLinkedVersionNumber("%1.%2.%3");


### PR DESCRIPTION
By default, the date and time of the build are embedded into the binary as sort of origin/version/etc. marker. This is not, however, reproducible. This patch makes it so that packagers can define a præprocessor macro, `ANTIMICROX_PKG_VERSION`, to a C string which is then used instead; if this macro is not defined nothing changes.

The diff comes from [Debian](https://github.com/AntiMicroX/antimicrox/issues/87); by upstreaming the new string can be translated.

Example use: add `-DANTIMICROX_PKG_VERSION=\"'3.1.4-1 (Debian sid/amd64)'\"` to `CPPFLAGS`. Check the Hel̲p → A̲bout dialogue, tab Info, second line, to see its effect.