### PR TITLE
Added notifs on set change

### DIFF
--- a/src/joytabwidget.cpp
+++ b/src/joytabwidget.cpp
@@ -62,7 +62,9 @@
 #include <QSpacerItem>
 #include <QStackedWidget>
 #include <QStringListIterator>
+#include <QSysInfo>
 #include <QTextStream>
+#include <QtGlobal>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -1295,6 +1297,17 @@ void JoyTabWidget::changeCurrentSet(int index)
         break;
     default:
         break;
+    }
+
+
+    if(m_settings->value("Notifications/notify_about_set_change", false).toBool()){
+
+        ///This only works if this is a Linux system. This gives the possibility to add windows and mac notifications later on
+        #if defined(Q_OS_LINUX)
+
+            ///This takes the message to be echoed to the shell, inserts index (much cleaner than before), and sends it to the shell, triggering the notification
+            system(qPrintable(QString("notify-send \"AntiMicroX\" \"Set %1 is now active\" --urgency=normal -i \"/home/guttmann/Desktop/antimicrox/src/icons/antimicrox.ico\"").arg(index + 1)));
+        #endif
     }
 
     if (activeSetButton != nullptr)

--- a/src/mainsettingsdialog.cpp
+++ b/src/mainsettingsdialog.cpp
@@ -164,6 +164,10 @@ MainSettingsDialog::MainSettingsDialog(AntiMicroSettings *settings, QList<InputD
         ui->launchInTrayCheckBox->setChecked(true);
     }
 
+    ui->showSetChangeNotification->setChecked(settings->value("Notifications/notify_about_set_change", false).toBool());
+
+    ui->showSetChangeNotification->setChecked(settings->value("Notifications/notify_about_set_change", false).toBool());
+
     ui->associateProfilesCheckBox->setVisible(false);
 
     ui->disableWindowsEnhancedPointCheckBox->setVisible(false);
@@ -535,6 +539,9 @@ void MainSettingsDialog::saveNewSettings()
 
     bool launchInTray = ui->launchInTrayCheckBox->isChecked();
     settings->setValue("LaunchInTray", launchInTray ? "1" : "0");
+
+    bool notify_set_change = ui->showSetChangeNotification->isChecked();
+    settings->setValue("Notifications/notify_about_set_change", notify_set_change);
 
     PadderCommon::lockInputDevices();
 
@@ -1887,6 +1894,7 @@ void MainSettingsDialog::resetGeneralSett()
     ui->launchInTrayCheckBox->setChecked(false);
     ui->associateProfilesCheckBox->setChecked(true);
     ui->keyRepeatEnableCheckBox->setChecked(false);
+    ui->showSetChangeNotification->setChecked(false);
 
     ui->keyDelayHorizontalSlider->setValue(660);
     ui->keyRateHorizontalSlider->setValue(25);

--- a/src/mainsettingsdialog.ui
+++ b/src/mainsettingsdialog.ui
@@ -331,6 +331,13 @@ first launches.</string>
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="showSetChangeNotification">
+           <property name="text">
+            <string>Show notifications when changing between sets. (Only works on Linux so far)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Closes #122 
## Proposed changes 

- Added notifications upon set changes
- Added the ability to disable the notifications (default is off)
- Tested the functionality w/ Dualshock 3 on Ubuntu 20.04.1 LTS

----


<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

