### PR TITLE
Refactor arguments parsing

### DIFF
--- a/src/commandlineutility.h
+++ b/src/commandlineutility.h
@@ -86,6 +86,12 @@ class CommandLineUtility : public QObject
   public:
     explicit CommandLineUtility(QObject *parent = nullptr);
 
+    /**
+     * @brief load and parse arguments from commandline
+     *
+     * @param parsed_app
+     * @exception std::runtime_error - in case of problems with parsing like unknown flag, wrong value etc
+     */
     void parseArguments(const QApplication &parsed_app);
 
     bool isLaunchInTrayEnabled();
@@ -98,7 +104,6 @@ class CommandLineUtility : public QObject
     bool shouldListControllers();
     bool shouldMapController();
     bool hasProfileInOptions();
-    bool hasError();
 
     int getControllerNumber();
     int getStartSetNumber();
@@ -108,7 +113,6 @@ class CommandLineUtility : public QObject
     QString getProfileLocation();
     QString getEventGenerator();
     QString getCurrentLogFile();
-    QString getErrorText();
 
     QList<int> *getJoyStartSetNumberList();
     QList<ControllerOptionsInfo> const &getControllerOptionsList();
@@ -119,12 +123,9 @@ class CommandLineUtility : public QObject
     Logger::LogLevel getCurrentLogLevel();
 
   protected:
-    void setErrorMessage(QString temp);
-
   private:
     bool launchInTray;
     bool hideTrayIcon;
-    bool encounteredError;
     bool hiddenRequest;
     bool unloadProfile;
     bool daemonMode;
@@ -139,7 +140,6 @@ class CommandLineUtility : public QObject
     QString controllerIDString;
     QString displayString;
     QString eventGenerator;
-    QString errorText;
     QString currentLogFile;
 
     Logger::LogLevel currentLogLevel;

--- a/src/commandlineutility.h
+++ b/src/commandlineutility.h
@@ -1,6 +1,7 @@
 /* antimicrox Gamepad to KB+M event mapper
  * Copyright (C) 2015 Travis Nickles <nickles.travis@gmail.com>
  * Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail>
+ * Copyright (C) 2021 Paweł Kotiuk <kotiuk@zohomail.eu>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +21,8 @@
 #define COMMANDLINEPARSER_H
 
 class QCommandLineParser;
+
+#include <QApplication>
 
 #include "logger.h"
 
@@ -83,7 +86,7 @@ class CommandLineUtility : public QObject
   public:
     explicit CommandLineUtility(QObject *parent = nullptr);
 
-    void parseArguments(QCommandLineParser *parser);
+    void parseArguments(const QApplication &parsed_app);
 
     bool isLaunchInTrayEnabled();
     bool isTrayHidden();
@@ -145,11 +148,11 @@ class CommandLineUtility : public QObject
 
     static QStringList eventGeneratorsList;
 
-    void parseArgsProfile(QCommandLineParser *parser);
-    void parseArgsPrControle(QCommandLineParser *parser);
-    void parseArgsUnload(QCommandLineParser *parser);
-    void parseArgsStartSet(QCommandLineParser *parser);
-    void parseArgsMap(QCommandLineParser *parser);
+    void parseArgsProfile(const QCommandLineParser &parser);
+    void parseArgsPrControle(const QCommandLineParser &parser);
+    void parseArgsUnload(const QCommandLineParser &parser);
+    void parseArgsStartSet(const QCommandLineParser &parser);
+    void parseArgsMap(const QCommandLineParser &parser);
 };
 
 #endif // COMMANDLINEPARSER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,6 @@
 #include "messagehandler.h"
 
 #include <QApplication>
-#include <QCommandLineParser>
 #include <QDebug>
 #include <QDir>
 #include <QException>
@@ -184,69 +183,12 @@ int main(int argc, char *argv[])
     QTextStream outstream(stdout);
     QTextStream errorstream(stderr);
 
-    QCommandLineParser parser;
-    parser.setApplicationDescription(
-        QCoreApplication::translate("antimicrox", "Graphical program used to map keyboard buttons and mouse controls to "
-                                                  "a "
-                                                  "gamepad. Useful for playing games with no gamepad support."));
-    parser.addHelpOption();
-    parser.addVersionOption();
+    
 
-    parser.addOptions({
-        // A boolean option with a single name (-p)
-        {"tray", QCoreApplication::translate("main", "Launch program in system tray only.")},
-        // A boolean option with multiple names (-f, --force)
-        {"no-tray", QCoreApplication::translate("main", "Launch program with the tray menu disabled")},
-        // An option with a value
-        {"hidden", QCoreApplication::translate("main", "Launch program without the main window displayed")},
-        {"profile",
-         QCoreApplication::translate("main", "Launch program with the configuration file selected as "
-                                             "the default for "
-                                             "selected controllers. Defaults to all controllers"),
-         QCoreApplication::translate("main", "location")},
-        {"profile-controller",
-         QCoreApplication::translate("main", "Apply configuration file to a specific controller. Value "
-                                             "can be a controller index, name, or GUID"),
-         QCoreApplication::translate("main", "value")},
-        {"unload", QCoreApplication::translate("main", "Unload currently enabled profile(s)"),
-         QCoreApplication::translate("main", "value(s)")},
-        {"startSet",
-         QCoreApplication::translate("main", "Start joysticks on a specific set. Value can be a "
-                                             "controller index, name, or GUID"),
-         QCoreApplication::translate("main", "number value")},
-        {{"daemon", "d"}, QCoreApplication::translate("main", "Launch program as a daemon. Use only on Linux.")},
-        {"log-level", QCoreApplication::translate("main", "Enable logging. Levels (from the least strict): warn,info,debug"),
-         QCoreApplication::translate("main", "log-type")},
-        {"log-file", QCoreApplication::translate("main", "Choose a file for logs writing"),
-         QCoreApplication::translate("main", "filename")},
-        {"eventgen",
-         QCoreApplication::translate("main", "Choose between using XTest support and uinput support "
-                                             "for event generation. Use only if you have "
-                                             "enabled xtest and uinput options on Linux or vmulti on "
-                                             "Windows. Default: xtest."),
-         QCoreApplication::translate("main", "event-generation-type"), "xtest"}, // default
-        {{"list", "l"},
-         QCoreApplication::translate("main", "Print information about joysticks detected by SDL. Use "
-                                             "only if you have sdl "
-                                             "library. You can check your controller index, name or "
-                                             "even GUID.")},
-        // {"display",
-        //     QCoreApplication::translate("main", "Use specified display for
-        //     X11 calls")},
-        // {"next",
-        //     QCoreApplication::translate("main", "Advance profile loading set
-        //     options")},
-        //  {"map",
-        //      QCoreApplication::translate("main", "Open game controller
-        //      mapping window of selected controller. Value can be
-        //      a controller index or GUID."),
-        //      QCoreApplication::translate("main", "value")},
-    });
-
-    parser.process(antimicrox);
+    
 
     CommandLineUtility cmdutility;
-    cmdutility.parseArguments(&parser);
+    cmdutility.parseArguments(antimicrox);
 
     Logger appLogger(&outstream, &errorstream);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,9 @@
 #include <QTranslator>
 #include <QtGlobal>
 
+#include <iostream>
+#include <stdexcept>
+
 #ifdef Q_OS_UNIX
     #include <signal.h>
     #include <unistd.h>
@@ -183,12 +186,17 @@ int main(int argc, char *argv[])
     QTextStream outstream(stdout);
     QTextStream errorstream(stderr);
 
-    
-
-    
-
     CommandLineUtility cmdutility;
-    cmdutility.parseArguments(antimicrox);
+
+    try
+    {
+        cmdutility.parseArguments(antimicrox);
+    } catch (const std::runtime_error &e)
+    {
+        std::cerr << e.what() << '\n';
+        std::cerr << "Closing\n";
+        return -1;
+    }
 
     Logger appLogger(&outstream, &errorstream);
 
@@ -276,10 +284,10 @@ int main(int argc, char *argv[])
         mainWindow.fillButtons();
         mainWindow.alterConfigFromSettings();
 
-        if (!cmdutility.hasError() && (cmdutility.hasProfile() || cmdutility.hasProfileInOptions()))
+        if (cmdutility.hasProfile() || cmdutility.hasProfileInOptions())
         {
             mainWindow.saveAppConfig();
-        } else if (!cmdutility.hasError() && cmdutility.isUnloadRequested())
+        } else if (cmdutility.isUnloadRequested())
         {
             mainWindow.saveAppConfig();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,7 +192,6 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.addVersionOption();
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
     parser.addOptions({
         // A boolean option with a single name (-p)
         {"tray", QCoreApplication::translate("main", "Launch program in system tray only.")},
@@ -243,55 +242,6 @@ int main(int argc, char *argv[])
         //      a controller index or GUID."),
         //      QCoreApplication::translate("main", "value")},
     });
-
-#else
-    parser.addOption(QCommandLineOption("tray", QObject::trUtf8("Launch program in system tray only.")));
-    parser.addOption(QCommandLineOption("no-tray", QObject::trUtf8("Launch program with the tray menu disabled")));
-    parser.addOption(QCommandLineOption("hidden", QObject::trUtf8("Launch program without the main window displayed")));
-
-    parser.addOption(QCommandLineOption("profile",
-                                        QObject::trUtf8("Launch program with the configuration file selected as the "
-                                                        "default "
-                                                        "for selected controllers. Defaults to all controllers"),
-                                        QObject::trUtf8("location")));
-
-    parser.addOption(QCommandLineOption("profile-controller",
-                                        QObject::trUtf8("Apply configuration file to a specific controller. "
-                                                        "Value can be a controller index, name, or GUID"),
-                                        QObject::trUtf8("value")));
-
-    parser.addOption(
-        QCommandLineOption("unload", QObject::trUtf8("Unload currently enabled profile(s)"), QObject::trUtf8("value(s)")));
-
-    parser.addOption(QCommandLineOption("startSet",
-                                        QObject::trUtf8("Start joysticks on a specific set. Value can be a "
-                                                        "controller index, name, or GUID"),
-                                        QObject::trUtf8("number value")));
-
-    parser.addOption(QCommandLineOption(QStringList() << "daemon"
-                                                      << "d",
-                                        QObject::trUtf8("Launch program as a daemon. Use only on Linux.")));
-
-    parser.addOption(QCommandLineOption("log-level", QObject::trUtf8("Enable logging"), QObject::trUtf8("log-type")));
-
-    parser.addOption(
-        QCommandLineOption("log-file", QObject::trUtf8("Choose a file for logs writing"), QObject::trUtf8("filename")));
-
-    parser.addOption(QCommandLineOption("eventgen",
-                                        QObject::trUtf8("Choose between using XTest support and uinput support "
-                                                        "for event generation. Use only if you have "
-                                                        "enabled xtest and uinput options on Linux or vmulti "
-                                                        "on Windows. Default: xtest."),
-                                        QObject::trUtf8("event-generation-type"), "xtest"));
-
-    parser.addOption(QCommandLineOption(QStringList() << "list"
-                                                      << "l",
-                                        QObject::trUtf8("Print information about joysticks detected by SDL. "
-                                                        "Use only if you have sdl "
-                                                        "library. You can check your controller index, name or "
-                                                        "even GUID.")));
-
-#endif
 
     parser.process(antimicrox);
 


### PR DESCRIPTION
This one is meant to clean up a bit way of parsing arguments

Things do to:

- [x] Entire parsing process should be done in parsing class (not in main.cpp)
- [x] Strict checks for arguments (now it is possible to open antimicrox with `--profile` argument pointing at wrong file)
- [x] Remove deprecated code used by qt versions older than 5.4.0