### PR TITLE
Allow regular users using uinput

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,8 +8,8 @@ Most of these packages are already built and available on [Release Page](https:/
     - [Build Options for CMake](#build-options-for-cmake)
     - [Universal Options](#universal-options)
     - [Linux Options](#linux-options)
-  - [Building deb package](#building-deb-package)
-  - [Building rpm package](#building-rpm-package)
+  - [Building DEB package](#building-deb-package)
+  - [Building RPM package](#building-rpm-package)
   - [Building AppImage](#building-appimage)
   - [Building Flatpak](#building-flatpak)
 
@@ -90,6 +90,7 @@ command for qm files. -noobsolete is a method for getting rid of obsolete text e
 Default: OFF. Allows for the launch of test sources with unit tests
 
     -DANTIMICROX_PKG_VERSION
+
 Default: Not defined. (feature intended for packagers) Manually define version of package displayed in info tab. When not defined building time is displayed instead.
 
 ### Linux Options
@@ -101,6 +102,10 @@ Default: ON. Build the project with AppData support.
     -DWITH_UINPUT
 
 Default: ON. Compile the program with uinput support.
+
+    -DINSTALL_UINPUT_UDEV_RULES
+
+Default: ON. During installation process create new udev rule allowing regular users using uinput.
 
     -DWITH_X11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ endif(WITH_TESTS)
 if(UNIX)
     option(WITH_X11 "Compile with support for X11." ON)
     option(WITH_UINPUT "Compile with support for uinput. uinput will be usable to simulate events." ON)
+    option(INSTALL_UINPUT_UDEV_RULES "Generate udev rules allowing users using uinput without root permissions." ON)
     option(WITH_XTEST "Compile with support for XTest.  XTest will be usable to simulate events." ON)
     option(APPDATA "Build project with AppData file support." ON)
 endif(UNIX)
@@ -110,6 +111,8 @@ if(UNIX)
 
     if(WITH_UINPUT)
         message("uinput support allowed for simulating events.")
+    else()
+        set(INSTALL_UINPUT_UDEV_RULES OFF)
     endif(WITH_UINPUT)
 
     if(NOT WITH_XTEST AND NOT WITH_UINPUT)
@@ -538,6 +541,13 @@ if(UNIX)
         # Only way to force install target to be dependent on appdata.
         install(CODE "execute_process(COMMAND ${CMAKE_BUILD_TOOL} appdata WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
     endif(APPDATA)
+endif(UNIX)
+
+if(UNIX)
+    if(INSTALL_UINPUT_UDEV_RULES)
+        message("Udev rules installation enabled.")
+        install(FILES other/60-antimcrox-uinput.rules DESTINATION "/usr/lib/udev/rules.d/")
+    endif(INSTALL_UINPUT_UDEV_RULES)
 endif(UNIX)
 
 # uninstall target

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 AntiMicroX is a graphical program used to map gamepad keys to keyboard, mouse, scripts and macros. You can use this program to control any desktop application with a gamepad on Linux. 
 It can be also used for generating SDL2 configuration (useful for mapping atypical gamepads to generic ones like xbox360).
 
-Currently we don't support Wayland ([#32](https://github.com/AntiMicroX/antimicrox/issues/32)) - your system has to be running X.org in order to run this program.
+We support Wayland and X.org.
 
 It allows mapping of gamepads/joystick buttons to:
 - keyboard buttons

--- a/other/40-uinput.rules
+++ b/other/40-uinput.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="misc", KERNEL=="uinput", MODE="0660", GROUP="uinput"

--- a/other/60-antimcrox-uinput.rules
+++ b/other/60-antimcrox-uinput.rules
@@ -1,0 +1,2 @@
+#Enable user access to keyboard using uinput event generator
+SUBSYSTEM=="misc", KERNEL=="uinput", TAG+="uaccess"


### PR DESCRIPTION
Closes: #32 

Allow non-root users to use event generation method based on uinput without root privileges.
