### PR TITLE
Update installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 AntiMicroX is a graphical program used to map gamepad keys to keyboard, mouse, scripts and macros. You can use this program to control any desktop application with a gamepad on Linux. 
 It can be also used for generating SDL2 configuration (useful for mapping atypical gamepads to generic ones like xbox360).
 
-We support X.org and Wayland (Wayland is not supported in flatpak package(.
+We support X.org and Wayland.
 
 It allows mapping of gamepads/joystick buttons to:
 - keyboard buttons
@@ -73,9 +73,18 @@ The flatpak version is distributed on Flathub, and runs on most major Linux dist
 
 If you have Flathub [set up](https://flatpak.org/setup/) already:
 
-```
+```bash
 flatpak install flathub io.github.antimicrox.antimicrox
 ```
+
+<details>
+  <summary>❕ Flatpak package may not work correctly with wayland (fix)</summary>
+  This is caused by missing udev rule. TO fix this issue you can apply udev rule by yourself.
+
+  <pre>
+cd /etc/udev/rules.d/
+sudo wget https://raw.githubusercontent.com/AntiMicroX/antimicrox/master/other/60-antimicrox-uinput.rules</pre>
+</details>
 
 ### AppImage
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ If you have Flathub [set up](https://flatpak.org/setup/) already:
 flatpak install flathub io.github.antimicrox.antimicrox
 ```
 
+### AppImage
+
+Download from the [release site](https://github.com/AntiMicroX/antimicrox/releases).
+
+It is recommended to use [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) with this package.
+
+### Debian/Ubuntu-based distributions
+
+Download from the [release site](https://github.com/AntiMicroX/antimicrox/releases) and install `.deb` package.
+
 ### Fedora
 
 ```
@@ -121,16 +131,6 @@ Install package
 ```bash
 pacman -S antimicrox
 ```
-
-### Debian/Ubuntu-based distributions:
-
-Download from the [release site](https://github.com/AntiMicroX/antimicrox/releases) and install `.deb` package.
-
-### AppImage
-
-Download from the [release site](https://github.com/AntiMicroX/antimicrox/releases).
-
-It is recommended to use [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) with this package.
 
 ### Building Yourself
 


### PR DESCRIPTION
- Reorder Installation instructions for packages (addresses one of changes proposed in https://github.com/AntiMicroX/antimicrox/pull/229 by @Daebis)
- Add information about udev workaround for flatpak users on wayland

Closes: #221 