### PR TITLE
fix: Missing autoprofile settings tab in Windows

### DIFF
--- a/src/gui/mainsettingsdialog.cpp
+++ b/src/gui/mainsettingsdialog.cpp
@@ -117,7 +117,7 @@ MainSettingsDialog::MainSettingsDialog(AntiMicroSettings *settings, QList<InputD
         delete ui->categoriesListWidget->item(2);
         ui->stackedWidget->removeWidget(ui->page_2);
     }
-#elif !defined(WITH_X11)
+#elif !defined(WITH_X11) && defined(Q_OS_UNIX)
     delete ui->categoriesListWidget->item(2);
     ui->stackedWidget->removeWidget(ui->page_2);
 #endif


### PR DESCRIPTION
Closes: #273 