### PR TITLE
Add experimental support for clang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,24 @@ on:
 jobs:
     # Build job for Ubuntu
     build-ubuntu:
-        name: Ubuntu 20.04 GCC
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - name: Ubuntu 20-04 GCC
+                      cc: gcc
+                      cxx: g++
+                      build-type: Debug
+                      experimental: false
+                    - name: Ubuntu 20-04 Clang
+                      cc: clang
+                      cxx: clang++
+                      build-type: Debug
+                      experimental: true
+
+        name: ${{ matrix.name }} ${{ matrix.build-type }}
         runs-on: ubuntu-20.04
+        continue-on-error: ${{ matrix.experimental }}
 
         steps:
             - uses: actions/checkout@v2
@@ -26,14 +42,17 @@ jobs:
               run: sudo apt-get update && sudo apt-get install extra-cmake-modules qttools5-dev qttools5-dev-tools libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext ninja-build
 
             - name: Configure CMake
-              run: cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B ${{ github.workspace }}/build
+              run: cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -B ${{ github.workspace }}/build
+              env:
+                  CXX: ${{ matrix.cxx }}
+                  CC: ${{ matrix.cc }}
 
             - name: Build AntiMicroX
-              run: cmake --build ${{ github.workspace }}/build --parallel 8
+              run: cmake --build ${{ github.workspace }}/build
 
     # Build job for Windows
     build-windows:
-        name: Windows Server 2019 MinGW
+        name: Windows Server 2019 MinGW Debug
         runs-on: windows-latest
         defaults:
             run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ if(COMPILER_SUPPORTS_CXX11)
     message("Build type: ${CMAKE_BUILD_TYPE}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -O0 -fno-omit-frame-pointer")
-    if(UNIX)
+    if(UNIX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -rdynamic")
-    endif(UNIX)
+    endif(UNIX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wstrict-null-sentinel -Wstrict-overflow=5 -Wundef -Wno-unused -std=c++11")
 else()
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
@@ -545,6 +545,10 @@ target_link_libraries(antimicrox
         ${X11_LIBS}
         ${SDL2_LIBRARIES}
         ${EXTRA_LIBS}
+        )
+
+target_include_directories(antimicrox PUBLIC
+        ${SDL2_INCLUDE_DIRS}/SDL2
         )
 
 ###############################


### PR DESCRIPTION
## Proposed changes 

- ci: add experimental clang workflow
    
    - Add clang build as experimental
    - remove parallel flag from ubuntu build, since ninja run in parallel by
    default
- fix: add missing flags for clang
    
    - disable -rdynamic for clang, not needed by clang
    - add include directories for sdl2, by default it is only detecting
    /usr/include

----
Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>

<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

