### PR TITLE
chore: Enable checking for updates for deb release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install extra-cmake-modules qttools5-dev qttools5-dev-tools libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext
 
             - name: Configure CMake
-              run: cmake -DCPACK_GENERATOR="DEB" -DCMAKE_BUILD_TYPE=Release -DANTIMICROX_PKG_VERSION="GitHub Release" -B ${{ github.workspace }}/build
+              run: cmake -DCPACK_GENERATOR="DEB" -DCMAKE_BUILD_TYPE=Release -DCHECK_FOR_UPDATES=ON -DANTIMICROX_PKG_VERSION="GitHub Release" -B ${{ github.workspace }}/build
 
             - name: Create Deb package
               id: create_deb

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -111,7 +111,7 @@ command for qm files. -noobsolete is a method for getting rid of obsolete text e
 
     -DCHECK_FOR_UPDATES
 
-Default: OFF. Show update button in GUI when newer version is available.
+Default: OFF. Show update button in GUI when newer version is available. Recommended for builds distributed without package management systems.
 
     -DWITH_TESTS
 


### PR DESCRIPTION
Follow up to https://github.com/AntiMicroX/antimicrox/pull/328

Enabling update checking for Debian builds downloaded from GitHub