### PR TITLE
Add QMutex

### DIFF
--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -32,6 +32,7 @@
 #include <QDebug>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
+#include <QMutex>
 
 GameController::GameController(SDL_GameController *controller, int deviceIndex, AntiMicroSettings *settings,
                                int counterUniques, QObject *parent)
@@ -163,10 +164,18 @@ void GameController::closeSDLDevice()
     }
 }
 
-int GameController::getNumberRawButtons() { return SDL_CONTROLLER_BUTTON_MAX; }
+int GameController::getNumberRawButtons()
+{
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+    return SDL_CONTROLLER_BUTTON_MAX;
+}
 
 int GameController::getNumberRawAxes()
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     qDebug() << "Controller has " << SDL_CONTROLLER_AXIS_MAX << " raw axes";
 
     return SDL_CONTROLLER_AXIS_MAX;
@@ -179,6 +188,9 @@ void GameController::setCounterUniques(int counter) { counterUniques = counter; 
 void GameController::fillContainers(QHash<int, SDL_GameControllerButton> &buttons, QHash<int, SDL_GameControllerAxis> &axes,
                                     QList<SDL_GameControllerButtonBind> &hatButtons)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     for (int i = 0; i < SDL_JoystickNumHats(getJoyHandle()); i++)
     {
         SDL_GameControllerButton currentButton = static_cast<SDL_GameControllerButton>(i);
@@ -221,6 +233,9 @@ void GameController::fillContainers(QHash<int, SDL_GameControllerButton> &button
 
 QString GameController::getBindStringForAxis(int index, bool)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     QString temp = QString();
 
     SDL_GameControllerButtonBind bind =
@@ -239,6 +254,9 @@ QString GameController::getBindStringForAxis(int index, bool)
 
 QString GameController::getBindStringForButton(int index, bool trueIndex)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     QString temp = QString();
 
     SDL_GameControllerButtonBind bind =

--- a/src/gui/flashbuttonwidget.cpp
+++ b/src/gui/flashbuttonwidget.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 #include <QStyle>
 #include <QWidget>
+#include <QMutex>
 
 FlashButtonWidget::FlashButtonWidget(QWidget *parent)
     : QPushButton(parent)
@@ -63,9 +64,12 @@ void FlashButtonWidget::unflash()
 
 void FlashButtonWidget::refreshLabel()
 {
-    setText(generateLabel());
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+    QString temp = generateLabel();
 
-    qDebug() << "label has been set: " << generateLabel();
+    setText(temp);
+    qDebug() << "label has been set: " << temp;
 }
 
 bool FlashButtonWidget::isButtonFlashing() { return isflashing; }

--- a/src/inputdevicebitarraystatus.cpp
+++ b/src/inputdevicebitarraystatus.cpp
@@ -25,10 +25,14 @@
 #include "setjoystick.h"
 
 #include <QDebug>
+#include <QMutex>
 
 InputDeviceBitArrayStatus::InputDeviceBitArrayStatus(InputDevice *device, bool readCurrent, QObject *parent)
     : QObject(parent)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     for (int i = 0; i < device->getNumberRawAxes(); i++)
     {
         SetJoystick *currentSet = device->getActiveSetJoystick();
@@ -74,6 +78,9 @@ InputDeviceBitArrayStatus::InputDeviceBitArrayStatus(InputDevice *device, bool r
 
 void InputDeviceBitArrayStatus::changeAxesStatus(int axisIndex, bool value)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     if ((axisIndex >= 0) && (axisIndex <= axesStatus.size()))
     {
         axesStatus.replace(axisIndex, value);
@@ -82,6 +89,9 @@ void InputDeviceBitArrayStatus::changeAxesStatus(int axisIndex, bool value)
 
 void InputDeviceBitArrayStatus::changeButtonStatus(int buttonIndex, bool value)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     if ((buttonIndex >= 0) && (buttonIndex <= getButtonStatusLocal().size()))
     {
         getButtonStatusLocal().setBit(buttonIndex, value);
@@ -90,6 +100,9 @@ void InputDeviceBitArrayStatus::changeButtonStatus(int buttonIndex, bool value)
 
 void InputDeviceBitArrayStatus::changeHatStatus(int hatIndex, bool value)
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     if ((hatIndex >= 0) && (hatIndex <= hatButtonStatus.size()))
     {
         hatButtonStatus.replace(hatIndex, value);
@@ -98,6 +111,9 @@ void InputDeviceBitArrayStatus::changeHatStatus(int hatIndex, bool value)
 
 QBitArray InputDeviceBitArrayStatus::generateFinalBitArray()
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     int totalArraySize = 0;
     totalArraySize = axesStatus.size() + hatButtonStatus.size() + getButtonStatusLocal().size();
     QBitArray aggregateBitArray(totalArraySize, false);
@@ -126,6 +142,9 @@ QBitArray InputDeviceBitArrayStatus::generateFinalBitArray()
 
 void InputDeviceBitArrayStatus::clearStatusValues()
 {
+    QMutex mutex;
+    QMutexLocker locker(&mutex);
+
     for (int i = 0; i < axesStatus.size(); i++)
         axesStatus.replace(i, false);
 


### PR DESCRIPTION
Protect generateLabel() and various SDL vars in gamecontroller class and axesStatus

I created QMutex object behind QMutexLocker that will get destroyed when method end in a clean way and easy to maintain.
These have been tested a lot by me and fixes all crashes when running the application but crashes can still happen if the user uses the Gui and changes something that is not stable in the application yet.

