### PR TITLE
Disable refreshing button balels after every slot activation

### DIFF
--- a/src/gui/flashbuttonwidget.cpp
+++ b/src/gui/flashbuttonwidget.cpp
@@ -63,9 +63,10 @@ void FlashButtonWidget::unflash()
 
 void FlashButtonWidget::refreshLabel()
 {
-    setText(generateLabel());
+    QString new_label = generateLabel();
+    setText(new_label);
 
-    qDebug() << "label has been set: " << generateLabel();
+    qDebug() << "label has been set: " << new_label;
 }
 
 bool FlashButtonWidget::isButtonFlashing() { return isflashing; }

--- a/src/joybutton.cpp
+++ b/src/joybutton.cpp
@@ -262,7 +262,7 @@ void JoyButton::joyEvent(bool pressed, bool ignoresets)
                     else
                         lastDistance = getMouseDistanceFromDeadZone();
 
-                    activeZoneTimer.start();
+                    // activeZoneTimer.start();
                 }
             }
             // Toogle is enabled and a controller button change has occurred.
@@ -659,7 +659,7 @@ void JoyButton::activateSlots()
             keyPressEvent();
         }
 
-        activeZoneTimer.start();
+        // activeZoneTimer.start();
     }
 }
 
@@ -3175,7 +3175,7 @@ void JoyButton::releaseActiveSlots()
             GlobalVariables::JoyButton::cursorRemainderY = 0;
         }
 
-        activeZoneTimer.start();
+        // activeZoneTimer.start();
     }
 }
 


### PR DESCRIPTION
Closes #133 

Potential fix for #133.  
It disables unnecessary (I hope so) calling `FlashButtonWidget::refreshLabel()` after every press and release of button.

