### PR TITLE
BUILD.md updates + ignore 'builds' dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build directories
 
 build/
+builds/
 build-dir/
 Build/
 .flatpak-builder/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -143,6 +143,13 @@ Default: ON. Compile the program with X11 support.
 
 Default: ON. Compile the program with XTest support.
 
+On some systems, particularly if you do not have QtCreator installed, you may notice that some debug info (in particular qDebug() statements) do not generate any output on a Linux terminal. To fix this, you can create a qtlogging.ini file:
+
+    mkdir ~/.config/QtProject
+    printf '[Rules]\n*.debug=true\nqt.*.debug=false\n' > ~/.config/QtProject/qtlogging.ini
+
+Once this file is created and has the debug rules present, it should be picked up and applied automatically the next time you run cmake to create a build.
+
 ## Building DEB package
 
 ```bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,6 +31,16 @@ installed on your system in order to build this program:
 - `itstool` (extracts messages from XML files and outputs PO template files, then merges translations from MO files to create translated XML files)
 - `gettext`
 
+
+<details>
+  <summary>Fedora dependencies</summary>
+
+    One-liner for installing above dependencies:
+
+        sudo dnf install git make cmake gcc cmake extra-cmake-modules qt5-qttools-devel SDL2-devel libXi-devel libXtst-devel libX11-devel itstool gettext-devel;
+
+</details>
+
 <details>
   <summary>Windows dependencies</summary>
     In case of Windows you need QT, SDL2 libraries, cmake and compiler (mingw for example).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,6 +153,10 @@ Default: ON. Compile the program with X11 support.
 
 Default: ON. Compile the program with XTest support.
 
+---
+
+**qDebug output on terminal:**
+
 On some systems, particularly if you do not have QtCreator installed, you may notice that some debug info (in particular qDebug() statements) do not generate any output on a Linux terminal. To fix this, you can create a qtlogging.ini file:
 
     mkdir ~/.config/QtProject


### PR DESCRIPTION
Added notes to build documentation + ignore 'builds' folder in addition to 'build' (to allow retaining of multiple builds for testing)

## Proposed changes 

- build doc: add note for resolving issue with qDebug not working on custom builds (more below)
- build doc: one-liner for installing dependencies on Fedora
- gitignore: ignore 'builds' folder in addition to 'build' (allows retaining multiple builds for testing)

----

The gitignore and dependency one-liner should be fairly straight-forward so I will focus on the note for resolving qDebug output not being displayed when running custom builds. This was something I came across while doing local builds related to testing/debugging prototypes for in issue 133 [as noted here](https://github.com/AntiMicroX/antimicrox/issues/133#issuecomment-1025015871) but it was not directly related to that issue. After discussing with pktiuk, it sounded like it would be ok to submit a PR for this doc change.

details (from comment in 133):

> Side note: while getting my builds going, I realized I was not getting any output for qDebug() statements on the terminal and eventually found creating a specific config file resolved the issue. Is that something I could create a ticket / PR for adding a note for in BUILDING.md ([diff here](https://github.com/zpangwin/antimicrox/commit/8bb37323891a8f6aee1627c9dd825f4278183bd1))? I think this only applies when it is being built and the user doesn't have QtCreator installed so probably doesn't impact the release binaries, but still nice to have a note.

If any part of the PR is not desired, please let me know and I will be happy to revise as instructed.