### PR TITLE
fix: Support obtaining bigger pid numbers from X11 windows

### DIFF
--- a/src/x11extras.cpp
+++ b/src/x11extras.cpp
@@ -268,7 +268,8 @@ int X11Extras::getApplicationPid(Window window)
 
         if ((status == 0) && (prop != nullptr))
         {
-            pid = prop[1] << 8;
+            pid = prop[2] << 16;
+            pid += prop[1] << 8;
             pid += prop[0];
             XFree(prop);
         }


### PR DESCRIPTION
Closes: https://github.com/AntiMicroX/antimicrox/issues/369  
Applies patch recommended by @Zinggi