### PR TITLE
Simplify FlashButtonWidget

### DIFF
--- a/src/gui/flashbuttonwidget.cpp
+++ b/src/gui/flashbuttonwidget.cpp
@@ -47,8 +47,6 @@ void FlashButtonWidget::flash()
 
     this->style()->unpolish(this);
     this->style()->polish(this);
-
-    emit flashed(isflashing);
 }
 
 void FlashButtonWidget::unflash()
@@ -57,8 +55,6 @@ void FlashButtonWidget::unflash()
 
     this->style()->unpolish(this);
     this->style()->polish(this);
-
-    emit flashed(isflashing);
 }
 
 void FlashButtonWidget::refreshLabel()

--- a/src/gui/flashbuttonwidget.h
+++ b/src/gui/flashbuttonwidget.h
@@ -43,9 +43,6 @@ class FlashButtonWidget : public QPushButton
     virtual void retranslateUi();
     bool ifDisplayNames();
 
-  signals:
-    void flashed(bool flashing);
-
   public slots:
     void refreshLabel();
     void toggleNameDisplay();

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -1,36 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>MainWindow</class>
-    <widget class="QMainWindow" name="MainWindow">
-        <property name="windowModality">
-            <enum>Qt::WindowModal</enum>
-        </property>
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>650</width>
-                <height>580</height>
-            </rect>
-        </property>
-        <property name="minimumSize">
-            <size>
-                <width>650</width>
-                <height>0</height>
-            </size>
-        </property>
-        <property name="windowTitle">
-            <string>AntiMicroX</string>
-        </property>
-        <property name="windowIcon">
-            <iconset theme="io.github.antimicrox.antimicrox">
-                <normaloff>.</normaloff>.
-            </iconset>
-        </property>
-        <property name="styleSheet">
-            <string notr="true">JoyButtonWidget[isflashing=&quot;true&quot;], JoyAxisWidget[isflashing=&quot;true&quot;], JoyControlStickPushButton[isflashing=&quot;true&quot;], JoyControlStickButtonPushButton[isflashing=&quot;true&quot;], DPadPushButton[isflashing=&quot;true&quot;] {
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>580</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>AntiMicroX</string>
+  </property>
+  <property name="windowIcon">
+   <iconset theme="io.github.antimicrox.antimicrox">
+    <normaloff>.</normaloff>.</iconset>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">FlashButtonWidget[isflashing=&quot;true&quot;] {
     background-color: rgb(0, 0, 255);
-	color: rgb(205, 197, 191); } QPushButton#setPushButton1[setActive=&quot;false&quot;], QPushButton#setPushButton2[setActive=&quot;false&quot;], QPushButton#setPushButton3[setActive=&quot;false&quot;], QPushButton#setPushButton4[setActive=&quot;false&quot;], QPushButton#setPushButton5[setActive=&quot;false&quot;], QPushButton#setPushButton6[setActive=&quot;false&quot;], QPushButton#setPushButton7[setActive=&quot;false&quot;], QPushButton#setPushButton8[setActive=&quot;false&quot;] {
+	color: rgb(205, 197, 191);
+}
+QPushButton#setPushButton1[setActive=&quot;false&quot;], QPushButton#setPushButton2[setActive=&quot;false&quot;], QPushButton#setPushButton3[setActive=&quot;false&quot;], QPushButton#setPushButton4[setActive=&quot;false&quot;], QPushButton#setPushButton5[setActive=&quot;false&quot;], QPushButton#setPushButton6[setActive=&quot;false&quot;], QPushButton#setPushButton7[setActive=&quot;false&quot;], QPushButton#setPushButton8[setActive=&quot;false&quot;] {
 	background-color: rgb(190, 190, 190);
 }
 
@@ -38,492 +39,492 @@ QStackedWidget#stackedWidget{
     padding-top: 10px; } QPushButton#namesPushButton[isDisplayingNames=&quot;true&quot;] {
 	background-color: rgb(192, 255, 192);
 }</string>
-        </property>
-        <widget class="QWidget" name="centralWidget">
-            <layout class="QVBoxLayout" name="verticalLayout">
-                <property name="leftMargin">
-                    <number>4</number>
-                </property>
-                <property name="topMargin">
-                    <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                    <number>0</number>
-                </property>
-                <item>
-                    <widget class="QStackedWidget" name="stackedWidget">
-                        <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                <horstretch>0</horstretch>
-                                <verstretch>0</verstretch>
-                            </sizepolicy>
-                        </property>
-                        <property name="frameShape">
-                            <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                            <enum>QFrame::Plain</enum>
-                        </property>
-                        <property name="lineWidth">
-                            <number>1</number>
-                        </property>
-                        <property name="currentIndex">
-                            <number>1</number>
-                        </property>
-                        <widget class="QWidget" name="page1">
-                            <layout class="QVBoxLayout" name="verticalLayout_2">
-                                <item>
-                                    <widget class="QLabel" name="label">
-                                        <property name="text">
-                                            <string>No Joysticks have been found.
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="leftMargin">
+     <number>4</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QStackedWidget" name="stackedWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Plain</enum>
+      </property>
+      <property name="lineWidth">
+       <number>1</number>
+      </property>
+      <property name="currentIndex">
+       <number>1</number>
+      </property>
+      <widget class="QWidget" name="page1">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>No Joysticks have been found.
  Please plug in a joystick and then choose the &quot;Update Joysticks&quot; option in the main menu</string>
-                                        </property>
-                                        <property name="scaledContents">
-                                            <bool>true</bool>
-                                        </property>
-                                        <property name="alignment">
-                                            <set>Qt::AlignCenter</set>
-                                        </property>
-                                        <property name="wordWrap">
-                                            <bool>true</bool>
-                                        </property>
-                                    </widget>
-                                </item>
-                            </layout>
-                        </widget>
-                        <widget class="QWidget" name="joystick_tabs">
-                            <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                </sizepolicy>
-                            </property>
-                            <layout class="QVBoxLayout" name="verticalLayout_3">
-                                <property name="leftMargin">
-                                    <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                    <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                    <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                    <number>0</number>
-                                </property>
-                                <item>
-                                    <widget class="JoyTabWidgetContainer" name="tabWidget">
-                                        <property name="enabled">
-                                            <bool>true</bool>
-                                        </property>
-                                        <property name="sizePolicy">
-                                            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                                <horstretch>0</horstretch>
-                                                <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                        </property>
-                                        <property name="layoutDirection">
-                                            <enum>Qt::LeftToRight</enum>
-                                        </property>
-                                        <property name="tabPosition">
-                                            <enum>QTabWidget::North</enum>
-                                        </property>
-                                        <property name="tabShape">
-                                            <enum>QTabWidget::Rounded</enum>
-                                        </property>
-                                        <property name="currentIndex">
-                                            <number>-1</number>
-                                        </property>
-                                        <property name="usesScrollButtons">
-                                            <bool>true</bool>
-                                        </property>
-                                        <property name="documentMode">
-                                            <bool>false</bool>
-                                        </property>
-                                        <property name="tabsClosable">
-                                            <bool>false</bool>
-                                        </property>
-                                        <property name="movable">
-                                            <bool>false</bool>
-                                        </property>
-                                    </widget>
-                                </item>
-                            </layout>
-                        </widget>
-                    </widget>
-                </item>
-                <item>
-                    <layout class="QHBoxLayout" name="bottombuttonslayout">
-                        <item>
-                            <widget class="QPushButton" name="uacPushButton">
-                                <property name="sizePolicy">
-                                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                                        <horstretch>1</horstretch>
-                                        <verstretch>0</verstretch>
-                                    </sizepolicy>
-                                </property>
-                                <property name="text">
-                                    <string>If events are not seen by a game, please click here to run this application as Administrator.</string>
-                                </property>
-                                <property name="autoDefault">
-                                    <bool>false</bool>
-                                </property>
-                                <property name="default">
-                                    <bool>false</bool>
-                                </property>
-                                <property name="flat">
-                                    <bool>false</bool>
-                                </property>
-                            </widget>
-                        </item>
-                        <item>
-                            <widget class="QPushButton" name="updateButton">
-                                <property name="sizePolicy">
-                                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                                        <horstretch>1</horstretch>
-                                        <verstretch>0</verstretch>
-                                    </sizepolicy>
-                                </property>
-                                <property name="text">
-                                    <string>Update Button</string>
-                                </property>
-                                <property name="autoDefault">
-                                    <bool>false</bool>
-                                </property>
-                                <property name="default">
-                                    <bool>false</bool>
-                                </property>
-                                <property name="flat">
-                                    <bool>false</bool>
-                                </property>
-                            </widget>
-                        </item>
-                    </layout>
-                </item>
-            </layout>
-        </widget>
-        <widget class="QMenuBar" name="menuBar">
-            <property name="geometry">
-                <rect>
-                    <x>0</x>
-                    <y>0</y>
-                    <width>650</width>
-                    <height>34</height>
-                </rect>
-            </property>
-            <widget class="QMenu" name="menuQuit">
-                <property name="title">
-                    <string>&amp;App</string>
-                </property>
-                <addaction name="actionHide"/>
-                <addaction name="actionQuit"/>
-            </widget>
-            <widget class="QMenu" name="menuOptions">
-                <property name="title">
-                    <string>&amp;Options</string>
-                </property>
-                <addaction name="actionProperties"/>
-                <addaction name="actionKeyValue"/>
-                <addaction name="actionGameController_Mapping"/>
-                <addaction name="actionCalibration"/>
-                <addaction name="actionStick_Pad_Assign"/>
-                <addaction name="actionOptions"/>
-                <addaction name="actionUpdate_Joysticks"/>
-            </widget>
-            <widget class="QMenu" name="menuHelp">
-                <property name="title">
-                    <string>He&amp;lp</string>
-                </property>
-                <addaction name="actionGitHubPage"/>
-                <addaction name="actionIssues"/>
-                <addaction name="actionWiki"/>
-                <addaction name="separator"/>
-                <addaction name="actionAbout"/>
-                <addaction name="actionAbout_Qt"/>
-            </widget>
-            <addaction name="menuQuit"/>
-            <addaction name="menuOptions"/>
-            <addaction name="menuHelp"/>
-        </widget>
-        <action name="actionQuit">
-            <property name="icon">
-                <iconset theme="application_exit" resource="../resources.qrc">
-                    <normaloff>:/images/actions/application_exit.png</normaloff>:/images/actions/application_exit.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Quit</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+Q</string>
-            </property>
-        </action>
-        <action name="actionUpdate_Joysticks">
-            <property name="enabled">
-                <bool>true</bool>
-            </property>
-            <property name="icon">
-                <iconset theme="view_refresh" resource="../resources.qrc">
-                    <normaloff>:/images/actions/view_refresh.png</normaloff>:/images/actions/view_refresh.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Update Joysticks</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+U</string>
-            </property>
-        </action>
-        <action name="actionHide">
-            <property name="icon">
-                <iconset theme="view_restore" resource="../resources.qrc">
-                    <normaloff>:/images/actions/view_restore.png</normaloff>:/images/actions/view_restore.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Hide</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+H</string>
-            </property>
-        </action>
-        <action name="actionAbout">
-            <property name="icon">
-                <iconset theme="about_antimicrox" resource="../resources.qrc">
-                    <normaloff>:/images/actions/about_antimicrox.png</normaloff>:/images/actions/about_antimicrox.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;About</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+A</string>
-            </property>
-        </action>
-        <action name="actionAbout_Qt">
-            <property name="icon">
-                <iconset theme="about_qt" resource="../resources.qrc">
-                    <normaloff>:/images/actions/about_qt.png</normaloff>:/images/actions/about_qt.png</iconset>
-            </property>
-            <property name="text">
-                <string>About &amp;Qt</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+T</string>
-            </property>
-        </action>
-        <action name="actionProperties">
-            <property name="icon">
-                <iconset theme="sliders" resource="../resources.qrc">
-                    <normaloff>:/images/actions/sliders.png</normaloff>:/images/actions/sliders.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Properties</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+P</string>
-            </property>
-        </action>
-        <action name="actionKeyValue">
-            <property name="icon">
-                <iconset theme="key_checker" resource="../resources.qrc">
-                    <normaloff>:/images/actions/key_checker.png</normaloff>:/images/actions/key_checker.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Key Checker</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+K</string>
-            </property>
-        </action>
-        <action name="actionHomePage">
-            <property name="text">
-                <string>Home Page</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+H</string>
-            </property>
-        </action>
-        <action name="actionGitHubPage">
-            <property name="icon">
-                <iconset theme="github_page" resource="../resources.qrc">
-                    <normaloff>:/images/actions/github_page.png</normaloff>:/images/actions/github_page.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;GitHub Page</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+G</string>
-            </property>
-        </action>
-        <action name="actionGameController_Mapping">
-            <property name="icon">
-                <iconset theme="map_controller" resource="../resources.qrc">
-                    <normaloff>:/images/actions/map_controller.png</normaloff>:/images/actions/map_controller.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Game Controller Mapping</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+M</string>
-            </property>
-        </action>
-        <action name="actionOptions">
-            <property name="icon">
-                <iconset theme="settings" resource="../resources.qrc">
-                    <normaloff>:/images/actions/settings.png</normaloff>:/images/actions/settings.png</iconset>
-            </property>
-            <property name="text">
-                <string>S&amp;ettings</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+S</string>
-            </property>
-        </action>
-        <action name="actionStick_Pad_Assign">
-            <property name="icon">
-                <iconset theme="stick_pad_assign" resource="../resources.qrc">
-                    <normaloff>:/images/actions/stick_pad_assign.png</normaloff>:/images/actions/stick_pad_assign.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Stick/Pad Assign</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+X</string>
-            </property>
-        </action>
-        <action name="actionWiki">
-            <property name="icon">
-                <iconset theme="wiki" resource="../resources.qrc">
-                    <normaloff>:/images/actions/wiki.png</normaloff>:/images/actions/wiki.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Wiki</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+W</string>
-            </property>
-        </action>
-        <action name="actionIssues">
-            <property name="icon">
-                <iconset theme="issues" resource="../resources.qrc">
-                    <normaloff>:/images/actions/issues.png</normaloff>:/images/actions/issues.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Issues</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+I</string>
-            </property>
-        </action>
-        <action name="actionCalibration">
-            <property name="icon">
-                <iconset theme="calibration" resource="../resources.qrc">
-                    <normaloff>:/images/actions/calibration.png</normaloff>:/images/actions/calibration.png</iconset>
-            </property>
-            <property name="text">
-                <string>&amp;Calibration</string>
-            </property>
-            <property name="shortcut">
-                <string>Ctrl+C</string>
-            </property>
-        </action>
-    </widget>
-    <layoutdefault spacing="6" margin="11"/>
-    <customwidgets>
-        <customwidget>
-            <class>JoyTabWidgetContainer</class>
-            <extends>QTabWidget</extends>
-            <header>joytabwidgetcontainer.h</header>
-            <container>1</container>
-        </customwidget>
-    </customwidgets>
-    <resources>
-        <include location="../resources.qrc"/>
-    </resources>
-    <connections>
-        <connection>
-            <sender>actionQuit</sender>
-            <signal>triggered()</signal>
-            <receiver>MainWindow</receiver>
-            <slot>quitProgram()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>199</x>
-                    <y>149</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionUpdate_Joysticks</sender>
-            <signal>triggered()</signal>
-            <receiver>MainWindow</receiver>
-            <slot>startJoystickRefresh()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>349</x>
-                    <y>262</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionHide</sender>
-            <signal>triggered()</signal>
-            <receiver>MainWindow</receiver>
-            <slot>hideWindow()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>349</x>
-                    <y>262</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionAbout</sender>
-            <signal>triggered()</signal>
-            <receiver>MainWindow</receiver>
-            <slot>openAboutDialog()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>349</x>
-                    <y>262</y>
-                </hint>
-            </hints>
-        </connection>
-        <connection>
-            <sender>actionStick_Pad_Assign</sender>
-            <signal>triggered()</signal>
-            <receiver>MainWindow</receiver>
-            <slot>showStickAssignmentDialog()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>-1</x>
-                    <y>-1</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>324</x>
-                    <y>289</y>
-                </hint>
-            </hints>
-        </connection>
-    </connections>
-    <slots>
-        <slot>startJoystickRefresh()</slot>
-        <slot>hideWindow()</slot>
-        <slot>openAboutDialog()</slot>
-        <slot>quitProgram()</slot>
-        <slot>showStickAssignmentDialog()</slot>
-    </slots>
+          </property>
+          <property name="scaledContents">
+           <bool>true</bool>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="joystick_tabs">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="JoyTabWidgetContainer" name="tabWidget">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="tabPosition">
+           <enum>QTabWidget::North</enum>
+          </property>
+          <property name="tabShape">
+           <enum>QTabWidget::Rounded</enum>
+          </property>
+          <property name="currentIndex">
+           <number>-1</number>
+          </property>
+          <property name="usesScrollButtons">
+           <bool>true</bool>
+          </property>
+          <property name="documentMode">
+           <bool>false</bool>
+          </property>
+          <property name="tabsClosable">
+           <bool>false</bool>
+          </property>
+          <property name="movable">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="bottombuttonslayout">
+      <item>
+       <widget class="QPushButton" name="uacPushButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>If events are not seen by a game, please click here to run this application as Administrator.</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>false</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="updateButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Update Button</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>false</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>650</width>
+     <height>24</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuQuit">
+    <property name="title">
+     <string>&amp;App</string>
+    </property>
+    <addaction name="actionHide"/>
+    <addaction name="actionQuit"/>
+   </widget>
+   <widget class="QMenu" name="menuOptions">
+    <property name="title">
+     <string>&amp;Options</string>
+    </property>
+    <addaction name="actionProperties"/>
+    <addaction name="actionKeyValue"/>
+    <addaction name="actionGameController_Mapping"/>
+    <addaction name="actionCalibration"/>
+    <addaction name="actionStick_Pad_Assign"/>
+    <addaction name="actionOptions"/>
+    <addaction name="actionUpdate_Joysticks"/>
+   </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>He&amp;lp</string>
+    </property>
+    <addaction name="actionGitHubPage"/>
+    <addaction name="actionIssues"/>
+    <addaction name="actionWiki"/>
+    <addaction name="separator"/>
+    <addaction name="actionAbout"/>
+    <addaction name="actionAbout_Qt"/>
+   </widget>
+   <addaction name="menuQuit"/>
+   <addaction name="menuOptions"/>
+   <addaction name="menuHelp"/>
+  </widget>
+  <action name="actionQuit">
+   <property name="icon">
+    <iconset theme="application_exit" resource="../resources.qrc">
+     <normaloff>:/images/actions/application_exit.png</normaloff>:/images/actions/application_exit.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Quit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
+  </action>
+  <action name="actionUpdate_Joysticks">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="view_refresh" resource="../resources.qrc">
+     <normaloff>:/images/actions/view_refresh.png</normaloff>:/images/actions/view_refresh.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Update Joysticks</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+U</string>
+   </property>
+  </action>
+  <action name="actionHide">
+   <property name="icon">
+    <iconset theme="view_restore" resource="../resources.qrc">
+     <normaloff>:/images/actions/view_restore.png</normaloff>:/images/actions/view_restore.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Hide</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+H</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="icon">
+    <iconset theme="about_antimicrox" resource="../resources.qrc">
+     <normaloff>:/images/actions/about_antimicrox.png</normaloff>:/images/actions/about_antimicrox.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;About</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
+   </property>
+  </action>
+  <action name="actionAbout_Qt">
+   <property name="icon">
+    <iconset theme="about_qt" resource="../resources.qrc">
+     <normaloff>:/images/actions/about_qt.png</normaloff>:/images/actions/about_qt.png</iconset>
+   </property>
+   <property name="text">
+    <string>About &amp;Qt</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+T</string>
+   </property>
+  </action>
+  <action name="actionProperties">
+   <property name="icon">
+    <iconset theme="sliders" resource="../resources.qrc">
+     <normaloff>:/images/actions/sliders.png</normaloff>:/images/actions/sliders.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Properties</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
+   </property>
+  </action>
+  <action name="actionKeyValue">
+   <property name="icon">
+    <iconset theme="key_checker" resource="../resources.qrc">
+     <normaloff>:/images/actions/key_checker.png</normaloff>:/images/actions/key_checker.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Key Checker</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+K</string>
+   </property>
+  </action>
+  <action name="actionHomePage">
+   <property name="text">
+    <string>Home Page</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+H</string>
+   </property>
+  </action>
+  <action name="actionGitHubPage">
+   <property name="icon">
+    <iconset theme="github_page" resource="../resources.qrc">
+     <normaloff>:/images/actions/github_page.png</normaloff>:/images/actions/github_page.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;GitHub Page</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+G</string>
+   </property>
+  </action>
+  <action name="actionGameController_Mapping">
+   <property name="icon">
+    <iconset theme="map_controller" resource="../resources.qrc">
+     <normaloff>:/images/actions/map_controller.png</normaloff>:/images/actions/map_controller.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Game Controller Mapping</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+M</string>
+   </property>
+  </action>
+  <action name="actionOptions">
+   <property name="icon">
+    <iconset theme="settings" resource="../resources.qrc">
+     <normaloff>:/images/actions/settings.png</normaloff>:/images/actions/settings.png</iconset>
+   </property>
+   <property name="text">
+    <string>S&amp;ettings</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionStick_Pad_Assign">
+   <property name="icon">
+    <iconset theme="stick_pad_assign" resource="../resources.qrc">
+     <normaloff>:/images/actions/stick_pad_assign.png</normaloff>:/images/actions/stick_pad_assign.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Stick/Pad Assign</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
+   </property>
+  </action>
+  <action name="actionWiki">
+   <property name="icon">
+    <iconset theme="wiki" resource="../resources.qrc">
+     <normaloff>:/images/actions/wiki.png</normaloff>:/images/actions/wiki.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Wiki</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+W</string>
+   </property>
+  </action>
+  <action name="actionIssues">
+   <property name="icon">
+    <iconset theme="issues" resource="../resources.qrc">
+     <normaloff>:/images/actions/issues.png</normaloff>:/images/actions/issues.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Issues</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+I</string>
+   </property>
+  </action>
+  <action name="actionCalibration">
+   <property name="icon">
+    <iconset theme="calibration" resource="../resources.qrc">
+     <normaloff>:/images/actions/calibration.png</normaloff>:/images/actions/calibration.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Calibration</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+C</string>
+   </property>
+  </action>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>JoyTabWidgetContainer</class>
+   <extends>QTabWidget</extends>
+   <header>joytabwidgetcontainer.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../resources.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>actionQuit</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>quitProgram()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>199</x>
+     <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionUpdate_Joysticks</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>startJoystickRefresh()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>349</x>
+     <y>262</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionHide</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>hideWindow()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>349</x>
+     <y>262</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionAbout</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>openAboutDialog()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>349</x>
+     <y>262</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionStick_Pad_Assign</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>showStickAssignmentDialog()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>289</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>startJoystickRefresh()</slot>
+  <slot>hideWindow()</slot>
+  <slot>openAboutDialog()</slot>
+  <slot>quitProgram()</slot>
+  <slot>showStickAssignmentDialog()</slot>
+ </slots>
 </ui>

--- a/src/joybuttonstatusbox.cpp
+++ b/src/joybuttonstatusbox.cpp
@@ -46,8 +46,6 @@ void JoyButtonStatusBox::flash()
 
     this->style()->unpolish(this);
     this->style()->polish(this);
-
-    emit flashed(isflashing);
 }
 
 void JoyButtonStatusBox::unflash()
@@ -56,6 +54,4 @@ void JoyButtonStatusBox::unflash()
 
     this->style()->unpolish(this);
     this->style()->polish(this);
-
-    emit flashed(isflashing);
 }

--- a/src/joybuttonstatusbox.h
+++ b/src/joybuttonstatusbox.h
@@ -34,9 +34,6 @@ class JoyButtonStatusBox : public QPushButton
     JoyButton *getJoyButton() const;
     bool isButtonFlashing();
 
-  signals:
-    void flashed(bool flashing);
-
   private slots:
     void flash();
     void unflash();


### PR DESCRIPTION
All child classes of FlashButtonWidget were explicitely listed in
the mainwindow's stylesheet. Hence, new child classes are not correctly
styled until they are added to the stylesheet as well.

As simplification, only add FlashButtonWidget itself to the main stylesheet
so that all child classes are automatically styled correctly.
Editing the stylesheet with QtDesigned caused the file to be
reformatted. Furthermore, remove the unused "flashed" signals.

I came across this suring implementation of #375.