### PR TITLE
Fix QTime::restart deprecation warning

### DIFF
--- a/src/joybutton.cpp
+++ b/src/joybutton.cpp
@@ -56,7 +56,7 @@ QList<PadderCommon::springModeInfo> JoyButton::springXSpeeds;
 QList<PadderCommon::springModeInfo> JoyButton::springYSpeeds;
 
 // Temporary test object to test old mouse time behavior.
-QTime JoyButton::testOldMouseTime;
+QElapsedTimer JoyButton::testOldMouseTime;
 
 // time when minislots next to each other in thread pool are waiting to execute function
 // at the same time
@@ -3612,7 +3612,7 @@ QString JoyButton::getDefaultButtonName() { return defaultButtonName; }
  *     send a cursor mode mouse event to the display server.
  */
 void JoyButton::moveMouseCursor(int &movedX, int &movedY, int &movedElapsed, QList<double> *mouseHistoryX,
-                                QList<double> *mouseHistoryY, QTime *testOldMouseTime, QTimer *staticMouseEventTimer,
+                                QList<double> *mouseHistoryY, QElapsedTimer *testOldMouseTime, QTimer *staticMouseEventTimer,
                                 int mouseRefreshRate, int mouseHistorySize, QList<JoyButton::mouseCursorInfo> *cursorXSpeeds,
                                 QList<JoyButton::mouseCursorInfo> *cursorYSpeeds, double &cursorRemainderX,
                                 double &cursorRemainderY, double weightModifier, int idleMouseRefrRate,
@@ -4197,7 +4197,7 @@ QList<PadderCommon::springModeInfo> *JoyButton::getSpringYSpeeds() { return &spr
 
 QTimer *JoyButton::getStaticMouseEventTimer() { return &staticMouseEventTimer; }
 
-QTime *JoyButton::getTestOldMouseTime() { return &testOldMouseTime; }
+QElapsedTimer *JoyButton::getTestOldMouseTime() { return &testOldMouseTime; }
 
 bool JoyButton::hasCursorEvents(QList<JoyButton::mouseCursorInfo> *cursorXSpeedsList,
                                 QList<JoyButton::mouseCursorInfo> *cursorYSpeedsList)
@@ -4244,7 +4244,8 @@ void JoyButton::setMouseHistorySize(int size, int maxMouseHistSize, int &mouseHi
  */
 void JoyButton::setMouseRefreshRate(int refresh, int &mouseRefreshRate, int idleMouseRefrRate,
                                     JoyButtonMouseHelper *mouseHelper, QList<double> *mouseHistoryX,
-                                    QList<double> *mouseHistoryY, QTime *testOldMouseTime, QTimer *staticMouseEventTimer)
+                                    QList<double> *mouseHistoryY, QElapsedTimer *testOldMouseTime,
+                                    QTimer *staticMouseEventTimer)
 {
     if ((refresh >= 1) && (refresh <= 16))
     {
@@ -4531,9 +4532,9 @@ int JoyButton::getSpringDeadCircleMultiplier() { return springDeadCircleMultipli
 
 double JoyButton::getCurrentSpringDeadCircle() { return (springDeadCircleMultiplier * 0.01); }
 
-void JoyButton::restartLastMouseTime(QTime *testOldMouseTime) { testOldMouseTime->restart(); }
+void JoyButton::restartLastMouseTime(QElapsedTimer *testOldMouseTime) { testOldMouseTime->restart(); }
 
-void JoyButton::setStaticMouseThread(QThread *thread, QTimer *staticMouseEventTimer, QTime *testOldMouseTime,
+void JoyButton::setStaticMouseThread(QThread *thread, QTimer *staticMouseEventTimer, QElapsedTimer *testOldMouseTime,
                                      int idleMouseRefrRate, JoyButtonMouseHelper *mouseHelper)
 {
     int oldInterval = staticMouseEventTimer->interval();
@@ -4556,7 +4557,7 @@ void JoyButton::indirectStaticMouseThread(QThread *thread, QTimer *staticMouseEv
 }
 
 bool JoyButton::shouldInvokeMouseEvents(QList<JoyButton *> *pendingMouseButtons, QTimer *staticMouseEventTimer,
-                                        QTime *testOldMouseTime)
+                                        QElapsedTimer *testOldMouseTime)
 {
     bool result = false;
 
@@ -4580,24 +4581,6 @@ void JoyButton::setExtraAccelerationCurve(JoyExtraAccelerationCurve curve)
 }
 
 JoyButton::JoyExtraAccelerationCurve JoyButton::getExtraAccelerationCurve() { return extraAccelCurve; }
-
-void JoyButton::copyExtraAccelerationState(JoyButton *srcButton)
-{
-    this->currentAccelMulti = srcButton->currentAccelMulti;
-    this->oldAccelMulti = srcButton->oldAccelMulti;
-    this->accelTravel = srcButton->accelTravel;
-
-    this->startingAccelerationDistance = srcButton->startingAccelerationDistance;
-    this->lastAccelerationDistance = srcButton->lastAccelerationDistance;
-    this->lastMouseDistance = srcButton->lastMouseDistance;
-
-    this->accelExtraDurationTime.setHMS(srcButton->accelExtraDurationTime.hour(), srcButton->accelExtraDurationTime.minute(),
-                                        srcButton->accelExtraDurationTime.second(),
-                                        srcButton->accelExtraDurationTime.msec());
-
-    updateMouseParams((srcButton->lastMouseDistance != 0.0), srcButton->updateStartingMouseDistance,
-                      srcButton->updateOldAccelMulti);
-}
 
 void JoyButton::setUpdateInitAccel(bool state) { this->updateInitAccelValues = state; }
 

--- a/src/joybutton.h
+++ b/src/joybutton.h
@@ -96,7 +96,6 @@ class JoyButton : public QObject
     void setJoyNumber(int index);
     void clearPendingEvent(); // JoyButtonEvents class
     void setCustomName(QString name);
-    void copyExtraAccelerationState(JoyButton *srcButton);
     void setUpdateInitAccel(bool state);
     void removeVDPad();
     void setIgnoreEventState(bool ignore); // JoyButtonEvents class
@@ -212,11 +211,11 @@ class JoyButton : public QObject
     static bool hasSpringEvents(QList<PadderCommon::springModeInfo> *springXSpeedsList,
                                 QList<PadderCommon::springModeInfo> *springYSpeedsList); // JoyButtonEvents class
     static bool shouldInvokeMouseEvents(QList<JoyButton *> *pendingMouseButtons, QTimer *staticMouseEventTimer,
-                                        QTime *testOldMouseTime); // JoyButtonEvents class
+                                        QElapsedTimer *testOldMouseTime);
 
     static void setWeightModifier(double modifier, double maxWeightModifier, double &weightModifier);
     static void moveMouseCursor(int &movedX, int &movedY, int &movedElapsed, QList<double> *mouseHistoryX,
-                                QList<double> *mouseHistoryY, QTime *testOldMouseTime, QTimer *staticMouseEventTimer,
+                                QList<double> *mouseHistoryY, QElapsedTimer *testOldMouseTime, QTimer *staticMouseEventTimer,
                                 int mouseRefreshRate, int mouseHistorySize, QList<JoyButton::mouseCursorInfo> *cursorXSpeeds,
                                 QList<JoyButton::mouseCursorInfo> *cursorYSpeeds, double &cursorRemainderX,
                                 double &cursorRemainderY, double weightModifier, int idleMouseRefrRate,
@@ -229,12 +228,13 @@ class JoyButton : public QObject
                                     QList<double> *mouseHistoryY);
     static void setMouseRefreshRate(int refresh, int &mouseRefreshRate, int idleMouseRefrRate,
                                     JoyButtonMouseHelper *mouseHelper, QList<double> *mouseHistoryX,
-                                    QList<double> *mouseHistoryY, QTime *testOldMouseTime, QTimer *staticMouseEventTimer);
+                                    QList<double> *mouseHistoryY, QElapsedTimer *testOldMouseTime,
+                                    QTimer *staticMouseEventTimer);
     static void setSpringModeScreen(int screen, int &springModeScreen);
     static void resetActiveButtonMouseDistances(JoyButtonMouseHelper *mouseHelper);
     static void setGamepadRefreshRate(int refresh, int &gamepadRefreshRate, JoyButtonMouseHelper *mouseHelper);
-    static void restartLastMouseTime(QTime *testOldMouseTime);
-    static void setStaticMouseThread(QThread *thread, QTimer *staticMouseEventTimer, QTime *testOldMouseTime,
+    static void restartLastMouseTime(QElapsedTimer *testOldMouseTime);
+    static void setStaticMouseThread(QThread *thread, QTimer *staticMouseEventTimer, QElapsedTimer *testOldMouseTime,
                                      int idleMouseRefrRate, JoyButtonMouseHelper *mouseHelper);
     static void indirectStaticMouseThread(QThread *thread, QTimer *staticMouseEventTimer, JoyButtonMouseHelper *mouseHelper);
     static void invokeMouseEvents(JoyButtonMouseHelper *mouseHelper); // JoyButtonEvents class
@@ -246,7 +246,7 @@ class JoyButton : public QObject
     static QList<PadderCommon::springModeInfo> *getSpringXSpeeds();
     static QList<PadderCommon::springModeInfo> *getSpringYSpeeds();
     static QTimer *getStaticMouseEventTimer(); // JoyButtonEvents class
-    static QTime *getTestOldMouseTime();
+    static QElapsedTimer *getTestOldMouseTime();
 
     JoyExtraAccelerationCurve getExtraAccelerationCurve();
 
@@ -629,9 +629,9 @@ class JoyButton : public QObject
     QElapsedTimer buttonHeldRelease;
     QElapsedTimer keyPressHold;
     QElapsedTimer buttonDelay;
-    QTime accelExtraDurationTime;
+    QElapsedTimer accelExtraDurationTime;
     QElapsedTimer cycleResetHold;
-    static QTime testOldMouseTime;
+    static QElapsedTimer testOldMouseTime;
 
     VDPad *m_vdpad;
     JoyMouseMovementMode mouseMode;

--- a/src/joybuttonslot.cpp
+++ b/src/joybuttonslot.cpp
@@ -84,7 +84,9 @@ JoyButtonSlot::JoyButtonSlot(JoyButtonSlot *slot, QObject *parent)
     this->m_distance = slot->getDistance();
     this->previousDistance = slot->getPreviousDistance();
     this->easingActive = slot->isEasingActive();
-    this->easingTime.fromString(slot->getEasingTime()->toString());
+    easingTime = QElapsedTimer();
+    if (slot->getEasingTime()->isValid())
+        easingTime.start();
     this->extraData = slot->getExtraData();
 
     /*
@@ -420,7 +422,7 @@ bool JoyButtonSlot::isEasingActive() { return easingActive; }
 
 void JoyButtonSlot::setEasingStatus(bool isActive) { easingActive = isActive; }
 
-QTime *JoyButtonSlot::getEasingTime() { return &easingTime; }
+QElapsedTimer *JoyButtonSlot::getEasingTime() { return &easingTime; }
 
 void JoyButtonSlot::setTextData(QString textData) { m_textData = textData; }
 
@@ -513,7 +515,9 @@ JoyButtonSlot &JoyButtonSlot::operator=(JoyButtonSlot *slot)
     this->m_distance = slot->getDistance();
     this->previousDistance = slot->getPreviousDistance();
     this->easingActive = slot->isEasingActive();
-    this->easingTime.fromString(slot->getEasingTime()->toString());
+    easingTime = QElapsedTimer();
+    if (slot->getEasingTime()->isValid())
+        easingTime.start();
     this->extraData = slot->getExtraData();
 
     if (slot->getMixSlots() != nullptr)

--- a/src/joybuttonslot.h
+++ b/src/joybuttonslot.h
@@ -108,7 +108,7 @@ class JoyButtonSlot : public QObject
 
     bool isEasingActive();
     void setEasingStatus(bool isActive);
-    QTime *getEasingTime();
+    QElapsedTimer *getEasingTime();
 
     void setTextData(QString textData);
     QString getTextData();
@@ -143,7 +143,7 @@ class JoyButtonSlot : public QObject
     double m_distance;
     double previousDistance;
     QElapsedTimer mouseInterval;
-    QTime easingTime;
+    QElapsedTimer easingTime;
     bool easingActive;
     QString m_textData;
     QVariant extraData;


### PR DESCRIPTION
Replace it with QElapsedTimer as the deprecation warning suggests.
Remove unused function JoyButton::copyExtraAccelerationState which was
unused since it was introduced in commit f9058369.

In the JoyButtonSlot copy constructor remove the hack that copies the
time via an intermediate string and replace it with a new timer because
setting the time of a QElapsedTimer is not supported.
The new timer is started when the source timer is running.
This should not be a problems because the easingTime is usually very
small and there are not used virtual inputs while users change settings.

Fixes #318.