### PR TITLE
Fix more easy deprecation warnings

### DIFF
--- a/src/applaunchhelper.cpp
+++ b/src/applaunchhelper.cpp
@@ -128,11 +128,10 @@ void AppLaunchHelper::printControllerList(QMap<SDL_JoystickID, InputDevice *> *j
 
 void AppLaunchHelper::changeSpringModeScreen()
 {
-    QDesktopWidget deskWid;
     int springScreen =
         settings->value("Mouse/SpringScreen", GlobalVariables::AntimicroSettings::defaultSpringScreen).toInt();
 
-    if (springScreen >= deskWid.screenCount())
+    if (springScreen >= QGuiApplication::screens().count())
     {
         springScreen = -1;
         settings->setValue("Mouse/SpringScreen", GlobalVariables::AntimicroSettings::defaultSpringScreen);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -214,8 +214,7 @@ void sendSpringEventRefactor(PadderCommon::springModeInfo *fullSpring, PadderCom
         PadderCommon::mouseHelperObj.mouseTimer.stop();
         BaseEventHandler *handler = EventHandlerFactory::getInstance()->handler();
 
-        if ((fullSpring->screen >= -1) &&
-            (fullSpring->screen >= PadderCommon::mouseHelperObj.getDesktopWidget()->screenCount()))
+        if ((fullSpring->screen >= -1) && (fullSpring->screen >= QGuiApplication::screens().count()))
         {
             fullSpring->screen = -1;
         }
@@ -310,8 +309,7 @@ void sendSpringEvent(PadderCommon::springModeInfo *fullSpring, PadderCommon::spr
         int currentMouseX = 0;
         int currentMouseY = 0;
 
-        if ((fullSpring->screen >= -1) &&
-            (fullSpring->screen >= PadderCommon::mouseHelperObj.getDesktopWidget()->screenCount()))
+        if ((fullSpring->screen >= -1) && (fullSpring->screen >= QGuiApplication::screens().count()))
         {
             fullSpring->screen = -1;
         }

--- a/src/gui/mainsettingsdialog.cpp
+++ b/src/gui/mainsettingsdialog.cpp
@@ -1811,9 +1811,7 @@ void MainSettingsDialog::fillSpringScreenPresets()
     ui->springScreenComboBox->clear();
     ui->springScreenComboBox->addItem(tr("Default"), QVariant(GlobalVariables::AntimicroSettings::defaultSpringScreen));
 
-    QDesktopWidget deskWid;
-
-    for (int i = 0; i < deskWid.screenCount(); i++)
+    for (int i = 0; i < QGuiApplication::screens().count(); i++)
     {
         ui->springScreenComboBox->addItem(QString(":%1").arg(i), QVariant(i));
     }

--- a/src/gui/mousesettingsdialog.h
+++ b/src/gui/mousesettingsdialog.h
@@ -42,7 +42,7 @@ class MouseSettingsDialog : public QDialog
     JoyButton::JoyExtraAccelerationCurve getExtraAccelCurveForIndex(int index);
 
     Ui::MouseSettingsDialog *ui;
-    QTime lastMouseStatUpdate;
+    QElapsedTimer lastMouseStatUpdate;
 
   public slots:
     void changeSettingsWidgetStatus(int index);


### PR DESCRIPTION
Do what the warnings suggest:
* Replace QDesktopWidget::screenCount() with
  QGuiApplication::screens().count(). The new function returns a list of
  QScreen pointers. Keep using the deprecated function
  where screens are accessed by index for now.
* Replace one missed QTime with QElapsedTimer.