### PR TITLE
Fix QHashIterator::hasPrevious() deprecation warnings

### DIFF
--- a/src/eventhandlers/uinputeventhandler.cpp
+++ b/src/eventhandlers/uinputeventhandler.cpp
@@ -574,13 +574,10 @@ void UInputEventHandler::sendTextEntryEvent(QString maintext)
 
             if (tempList.size() > 0)
             {
-                QListIterator<unsigned int> tempiter(tempList);
-                tempiter.toBack();
-
-                while (tempiter.hasPrevious())
+                for (auto iter = tempList.crbegin(); iter != tempList.crend(); ++iter)
                 {
-                    unsigned int currentcode = tempiter.previous();
-                    bool sync = !tempiter.hasPrevious() ? true : false;
+                    unsigned int currentcode = *iter;
+                    bool sync = std::next(iter) == tempList.crend();
                     write_uinput_event(keyboardFileHandler, EV_KEY, currentcode, 0, sync);
                 }
             }

--- a/src/eventhandlers/winsendinputeventhandler.cpp
+++ b/src/eventhandlers/winsendinputeventhandler.cpp
@@ -170,11 +170,10 @@ void WinSendInputEventHandler::sendTextEntryEvent(QString maintext)
             {
                 INPUT tempBuffer[tempList.size()] = {0};
 
-                QListIterator<unsigned int> tempiter(tempList);
                 unsigned int j = 0;
-                while (tempiter.hasNext())
+                for (auto iter = tempList.cbegin(); iter != tempList.cend(); ++iter, ++j)
                 {
-                    unsigned int tempcode = tempiter.next();
+                    unsigned int tempcode = *iter;
                     unsigned int scancode = WinExtras::scancodeFromVirtualKey(tempcode);
                     int extended = (scancode & WinExtras::EXTENDED_FLAG) != 0;
                     int tempflags = extended ? KEYEVENTF_EXTENDEDKEY : 0;
@@ -186,18 +185,16 @@ void WinSendInputEventHandler::sendTextEntryEvent(QString maintext)
 
                     tempBuffer[j].ki.wVk = tempcode;
                     tempBuffer[j].ki.dwFlags = tempflags;
-                    j++;
                 }
 
                 SendInput(j, tempBuffer, sizeof(INPUT));
 
-                tempiter.toBack();
                 j = 0;
                 memset(tempBuffer, 0, sizeof(tempBuffer));
                 // INPUT tempBuffer2[tempList.size()] = {0};
-                while (tempiter.hasPrevious())
+                for (auto iter = tempList.crbegin(); iter != tempList.crend(); ++iter, ++j)
                 {
-                    unsigned int tempcode = tempiter.previous();
+                    unsigned int tempcode = *iter;
                     unsigned int scancode = WinExtras::scancodeFromVirtualKey(tempcode);
                     int extended = (scancode & WinExtras::EXTENDED_FLAG) != 0;
                     int tempflags = extended ? KEYEVENTF_EXTENDEDKEY : 0;
@@ -209,7 +206,6 @@ void WinSendInputEventHandler::sendTextEntryEvent(QString maintext)
 
                     tempBuffer[j].ki.wVk = tempcode;
                     tempBuffer[j].ki.dwFlags = tempflags | KEYEVENTF_KEYUP;
-                    j++;
                 }
 
                 SendInput(j, tempBuffer, sizeof(INPUT));

--- a/src/eventhandlers/xtesteventhandler.cpp
+++ b/src/eventhandlers/xtesteventhandler.cpp
@@ -158,12 +158,9 @@ void XTestEventHandler::sendTextEntryEvent(QString maintext)
 
                 if (tempList.size() > 0)
                 {
-                    QListIterator<int> tempiter(tempList);
-                    tempiter.toBack();
-
-                    while (tempiter.hasPrevious())
+                    for (auto iter = tempList.crbegin(); iter != tempList.crend(); ++iter)
                     {
-                        int currentcode = tempiter.previous();
+                        int currentcode = *iter;
                         XTestFakeKeyEvent(display, currentcode, 0, 0);
                     }
 

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -1875,24 +1875,23 @@ bool JoyControlStick::hasSameButtonsMouseMode()
 
     JoyButton::JoyMouseMovementMode initialMode = JoyButton::MouseCursor;
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    initialMode = button->getMouseMode();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            initialMode = button->getMouseMode();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
+        button = iter.value();
+        JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
 
-            if (temp != initialMode)
-            {
-                result = false;
-                iter.toBack();
-            }
+        if (temp != initialMode)
+        {
+            result = false;
+            break;
         }
     }
 
@@ -1903,24 +1902,23 @@ JoyButton::JoyMouseMovementMode JoyControlStick::getButtonsPresetMouseMode()
 {
     JoyButton::JoyMouseMovementMode resultMode = JoyButton::MouseCursor;
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return resultMode;
+
+    JoyControlStickButton *button = iter.value();
+    resultMode = button->getMouseMode();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            resultMode = button->getMouseMode();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
+        button = iter.value();
+        JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
 
-            if (temp != resultMode)
-            {
-                resultMode = JoyButton::MouseCursor;
-                iter.toBack();
-            }
+        if (temp != resultMode)
+        {
+            resultMode = JoyButton::MouseCursor;
+            break;
         }
     }
 
@@ -1944,24 +1942,23 @@ bool JoyControlStick::hasSameButtonsMouseCurve()
 
     JoyButton::JoyMouseCurve initialCurve = JoyButton::LinearCurve;
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    initialCurve = button->getMouseCurve();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            initialCurve = button->getMouseCurve();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            JoyButton::JoyMouseCurve temp = button->getMouseCurve();
+        button = iter.value();
+        JoyButton::JoyMouseCurve temp = button->getMouseCurve();
 
-            if (temp != initialCurve)
-            {
-                result = false;
-                iter.toBack();
-            }
+        if (temp != initialCurve)
+        {
+            result = false;
+            break;
         }
     }
 
@@ -1972,24 +1969,23 @@ JoyButton::JoyMouseCurve JoyControlStick::getButtonsPresetMouseCurve()
 {
     JoyButton::JoyMouseCurve resultCurve = JoyButton::LinearCurve;
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return resultCurve;
+
+    JoyControlStickButton *button = iter.value();
+    resultCurve = button->getMouseCurve();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            resultCurve = button->getMouseCurve();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            JoyButton::JoyMouseCurve temp = button->getMouseCurve();
+        button = iter.value();
+        JoyButton::JoyMouseCurve temp = button->getMouseCurve();
 
-            if (temp != resultCurve)
-            {
-                resultCurve = JoyButton::LinearCurve;
-                iter.toBack();
-            }
+        if (temp != resultCurve)
+        {
+            resultCurve = JoyButton::LinearCurve;
+            break;
         }
     }
 
@@ -2023,25 +2019,23 @@ int JoyControlStick::getButtonsPresetSpringWidth()
     int presetSpringWidth = 0;
 
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return presetSpringWidth;
+
+    JoyControlStickButton *button = iter.value();
+    presetSpringWidth = button->getSpringWidth();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            presetSpringWidth = button->getSpringWidth();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
+        button = iter.value();
+        int temp = button->getSpringWidth();
 
-            int temp = button->getSpringWidth();
-
-            if (temp != presetSpringWidth)
-            {
-                presetSpringWidth = 0;
-                iter.toBack();
-            }
+        if (temp != presetSpringWidth)
+        {
+            presetSpringWidth = 0;
+            break;
         }
     }
 
@@ -2053,24 +2047,23 @@ int JoyControlStick::getButtonsPresetSpringHeight()
     int presetSpringHeight = 0;
 
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return presetSpringHeight;
+
+    JoyControlStickButton *button = iter.value();
+    presetSpringHeight = button->getSpringHeight();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            presetSpringHeight = button->getSpringHeight();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            int temp = button->getSpringHeight();
+        button = iter.value();
+        int temp = button->getSpringHeight();
 
-            if (temp != presetSpringHeight)
-            {
-                presetSpringHeight = 0;
-                iter.toBack();
-            }
+        if (temp != presetSpringHeight)
+        {
+            presetSpringHeight = 0;
+            break;
         }
     }
 
@@ -2093,24 +2086,23 @@ double JoyControlStick::getButtonsPresetSensitivity()
     double presetSensitivity = 1.0;
 
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return presetSensitivity;
+
+    JoyControlStickButton *button = iter.value();
+    presetSensitivity = button->getSensitivity();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            presetSensitivity = button->getSensitivity();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            double temp = button->getSensitivity();
+        button = iter.value();
+        double temp = button->getSensitivity();
 
-            if (!qFuzzyCompare(temp, presetSensitivity))
-            {
-                presetSensitivity = 1.0;
-                iter.toBack();
-            }
+        if (!qFuzzyCompare(temp, presetSensitivity))
+        {
+            presetSensitivity = 1.0;
+            break;
         }
     }
 
@@ -2636,24 +2628,23 @@ bool JoyControlStick::isRelativeSpring()
     bool relative = false;
 
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return relative;
+
+    JoyControlStickButton *button = iter.value();
+    relative = button->isRelativeSpring();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            relative = button->isRelativeSpring();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            bool temp = button->isRelativeSpring();
+        button = iter.value();
+        bool temp = button->isRelativeSpring();
 
-            if (temp != relative)
-            {
-                relative = false;
-                iter.toBack();
-            }
+        if (temp != relative)
+        {
+            relative = false;
+            break;
         }
     }
 
@@ -2757,24 +2748,23 @@ double JoyControlStick::getButtonsEasingDuration()
 {
     double result = GlobalVariables::JoyButton::DEFAULTEASINGDURATION;
     QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(temphash);
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    result = button->getEasingDuration();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
-        {
-            JoyControlStickButton *button = iter.next().value();
-            result = button->getEasingDuration();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            double temp = button->getEasingDuration();
+        button = iter.value();
+        double temp = button->getEasingDuration();
 
-            if (!qFuzzyCompare(temp, result))
-            {
-                result = GlobalVariables::JoyButton::DEFAULTEASINGDURATION;
-                iter.toBack();
-            }
+        if (!qFuzzyCompare(temp, result))
+        {
+            result = GlobalVariables::JoyButton::DEFAULTEASINGDURATION;
+            break;
         }
     }
 
@@ -2860,30 +2850,27 @@ void JoyControlStick::setButtonsExtraAccelerationMultiplier(double value)
 double JoyControlStick::getButtonsExtraAccelerationMultiplier()
 {
     double result = GlobalVariables::JoyButton::DEFAULTEXTRACCELVALUE;
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
+    if (iter == temphash.cend())
+        return result;
 
-    while (iter.hasNext())
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getExtraAccelerationMultiplier();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
+            double temp = button->getExtraAccelerationMultiplier();
 
-            if (button != nullptr)
-                result = button->getExtraAccelerationMultiplier();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-
-            if (button != nullptr)
+            if (!qFuzzyCompare(temp, result))
             {
-                double temp = button->getExtraAccelerationMultiplier();
-
-                if (!qFuzzyCompare(temp, result))
-                {
-                    result = GlobalVariables::JoyButton::DEFAULTEXTRACCELVALUE;
-                    iter.toBack();
-                }
+                result = GlobalVariables::JoyButton::DEFAULTEXTRACCELVALUE;
+                break;
             }
         }
     }
@@ -2907,29 +2894,27 @@ void JoyControlStick::setButtonsStartAccelerationMultiplier(double value)
 double JoyControlStick::getButtonsStartAccelerationMultiplier()
 {
     double result = GlobalVariables::JoyButton::DEFAULTSTARTACCELMULTIPLIER;
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getStartAccelMultiplier();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
+            double temp = button->getStartAccelMultiplier();
 
-            if (button != nullptr)
-                result = button->getStartAccelMultiplier();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-
-            if (button != nullptr)
+            if (!qFuzzyCompare(temp, result))
             {
-                double temp = button->getStartAccelMultiplier();
-
-                if (!qFuzzyCompare(temp, result))
-                {
-                    result = GlobalVariables::JoyButton::DEFAULTSTARTACCELMULTIPLIER;
-                    iter.toBack();
-                }
+                result = GlobalVariables::JoyButton::DEFAULTSTARTACCELMULTIPLIER;
+                break;
             }
         }
     }
@@ -2953,30 +2938,27 @@ void JoyControlStick::setButtonsMinAccelerationThreshold(double value)
 double JoyControlStick::getButtonsMinAccelerationThreshold()
 {
     double result = GlobalVariables::JoyButton::DEFAULTMINACCELTHRESHOLD;
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
+    if (iter == temphash.cend())
+        return result;
 
-    while (iter.hasNext())
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getMinAccelThreshold();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
+            double temp = button->getMinAccelThreshold();
 
-            if (button != nullptr)
-                result = button->getMinAccelThreshold();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-
-            if (button != nullptr)
+            if (!qFuzzyCompare(temp, result))
             {
-                double temp = button->getMinAccelThreshold();
-
-                if (!qFuzzyCompare(temp, result))
-                {
-                    result = GlobalVariables::JoyButton::DEFAULTMINACCELTHRESHOLD;
-                    iter.toBack();
-                }
+                result = GlobalVariables::JoyButton::DEFAULTMINACCELTHRESHOLD;
+                break;
             }
         }
     }
@@ -3000,29 +2982,27 @@ void JoyControlStick::setButtonsMaxAccelerationThreshold(double value)
 double JoyControlStick::getButtonsMaxAccelerationThreshold()
 {
     double result = GlobalVariables::JoyButton::DEFAULTMAXACCELTHRESHOLD;
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getMaxAccelThreshold();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
+            double temp = button->getMaxAccelThreshold();
 
-            if (button != nullptr)
-                result = button->getMaxAccelThreshold();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-
-            if (button != nullptr)
+            if (!qFuzzyCompare(temp, result))
             {
-                double temp = button->getMaxAccelThreshold();
-
-                if (!qFuzzyCompare(temp, result))
-                {
-                    result = GlobalVariables::JoyButton::DEFAULTMAXACCELTHRESHOLD;
-                    iter.toBack();
-                }
+                result = GlobalVariables::JoyButton::DEFAULTMAXACCELTHRESHOLD;
+                break;
             }
         }
     }
@@ -3046,27 +3026,26 @@ void JoyControlStick::setButtonsAccelerationExtraDuration(double value)
 double JoyControlStick::getButtonsAccelerationEasingDuration()
 {
     double result = GlobalVariables::JoyButton::DEFAULTACCELEASINGDURATION;
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getAccelExtraDuration();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
-
-            if (button != nullptr)
-                result = button->getAccelExtraDuration();
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            if (button != nullptr)
+            double temp = button->getAccelExtraDuration();
+            if (!qFuzzyCompare(temp, result))
             {
-                double temp = button->getAccelExtraDuration();
-                if (!qFuzzyCompare(temp, result))
-                {
-                    result = GlobalVariables::JoyButton::DEFAULTACCELEASINGDURATION;
-                    iter.toBack();
-                }
+                result = GlobalVariables::JoyButton::DEFAULTACCELEASINGDURATION;
+                break;
             }
         }
     }
@@ -3090,28 +3069,26 @@ void JoyControlStick::setButtonsSpringDeadCircleMultiplier(int value)
 int JoyControlStick::getButtonsSpringDeadCircleMultiplier()
 {
     int result = GlobalVariables::JoyButton::DEFAULTSPRINGRELEASERADIUS;
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getSpringDeadCircleMultiplier();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
-            if (button != nullptr)
+            int temp = button->getSpringDeadCircleMultiplier();
+            if (temp != result)
             {
-                result = button->getSpringDeadCircleMultiplier();
-            }
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            if (button != nullptr)
-            {
-                int temp = button->getSpringDeadCircleMultiplier();
-                if (temp != result)
-                {
-                    result = GlobalVariables::JoyButton::DEFAULTSPRINGRELEASERADIUS;
-                    iter.toBack();
-                }
+                result = GlobalVariables::JoyButton::DEFAULTSPRINGRELEASERADIUS;
+                break;
             }
         }
     }
@@ -3827,28 +3804,26 @@ void JoyControlStick::setButtonsExtraAccelCurve(JoyButton::JoyExtraAccelerationC
 JoyButton::JoyExtraAccelerationCurve JoyControlStick::getButtonsExtraAccelerationCurve()
 {
     JoyButton::JoyExtraAccelerationCurve result = JoyButton::LinearAccelCurve;
+    QHash<JoyStickDirections, JoyControlStickButton *> temphash = getApplicableButtons();
+    auto iter = temphash.cbegin();
 
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(getApplicableButtons());
-    while (iter.hasNext())
+    if (iter == temphash.cend())
+        return result;
+
+    JoyControlStickButton *button = iter.value();
+    if (button != nullptr)
+        result = button->getExtraAccelerationCurve();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        if (button != nullptr)
         {
-            JoyControlStickButton *button = iter.next().value();
-            if (button != nullptr)
+            JoyButton::JoyExtraAccelerationCurve temp = button->getExtraAccelerationCurve();
+            if (temp != result)
             {
-                result = button->getExtraAccelerationCurve();
-            }
-        } else
-        {
-            JoyControlStickButton *button = iter.next().value();
-            if (button != nullptr)
-            {
-                JoyButton::JoyExtraAccelerationCurve temp = button->getExtraAccelerationCurve();
-                if (temp != result)
-                {
-                    result = JoyButton::LinearAccelCurve;
-                    iter.toBack();
-                }
+                result = JoyButton::LinearAccelCurve;
+                break;
             }
         }
     }

--- a/src/joydpad.cpp
+++ b/src/joydpad.cpp
@@ -252,24 +252,23 @@ bool JoyDPad::hasSameButtonsMouseMode()
     bool result = true;
 
     JoyButton::JoyMouseMovementMode initialMode = JoyButton::MouseCursor;
-
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return result;
+
+    JoyDPadButton *button = iter.value();
+    initialMode = button->getMouseMode();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
+        if (temp != initialMode)
         {
-            JoyDPadButton *button = iter.next().value();
-            initialMode = button->getMouseMode();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
-            if (temp != initialMode)
-            {
-                result = false;
-                iter.toBack();
-            }
+            result = false;
+            break;
         }
     }
 
@@ -281,22 +280,22 @@ JoyButton::JoyMouseMovementMode JoyDPad::getButtonsPresetMouseMode()
     JoyButton::JoyMouseMovementMode resultMode = JoyButton::MouseCursor;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return resultMode;
+
+    JoyDPadButton *button = iter.value();
+    resultMode = button->getMouseMode();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
+        if (temp != resultMode)
         {
-            JoyDPadButton *button = iter.next().value();
-            resultMode = button->getMouseMode();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            JoyButton::JoyMouseMovementMode temp = button->getMouseMode();
-            if (temp != resultMode)
-            {
-                resultMode = JoyButton::MouseCursor;
-                iter.toBack();
-            }
+            resultMode = JoyButton::MouseCursor;
+            break;
         }
     }
 
@@ -320,22 +319,22 @@ bool JoyDPad::hasSameButtonsMouseCurve()
     JoyButton::JoyMouseCurve initialCurve = JoyButton::LinearCurve;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return result;
+
+    JoyDPadButton *button = iter.value();
+    initialCurve = button->getMouseCurve();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        JoyButton::JoyMouseCurve temp = button->getMouseCurve();
+        if (temp != initialCurve)
         {
-            JoyDPadButton *button = iter.next().value();
-            initialCurve = button->getMouseCurve();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            JoyButton::JoyMouseCurve temp = button->getMouseCurve();
-            if (temp != initialCurve)
-            {
-                result = false;
-                iter.toBack();
-            }
+            result = false;
+            break;
         }
     }
 
@@ -347,22 +346,22 @@ JoyButton::JoyMouseCurve JoyDPad::getButtonsPresetMouseCurve()
     JoyButton::JoyMouseCurve resultCurve = JoyButton::LinearCurve;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return resultCurve;
+
+    JoyDPadButton *button = iter.value();
+    resultCurve = button->getMouseCurve();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        JoyButton::JoyMouseCurve temp = button->getMouseCurve();
+        if (temp != resultCurve)
         {
-            JoyDPadButton *button = iter.next().value();
-            resultCurve = button->getMouseCurve();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            JoyButton::JoyMouseCurve temp = button->getMouseCurve();
-            if (temp != resultCurve)
-            {
-                resultCurve = JoyButton::LinearCurve;
-                iter.toBack();
-            }
+            resultCurve = JoyButton::LinearCurve;
+            break;
         }
     }
 
@@ -394,22 +393,22 @@ int JoyDPad::getButtonsPresetSpringWidth()
     int presetSpringWidth = 0;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return presetSpringWidth;
+
+    JoyDPadButton *button = iter.value();
+    presetSpringWidth = button->getSpringWidth();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        int temp = button->getSpringWidth();
+        if (temp != presetSpringWidth)
         {
-            JoyDPadButton *button = iter.next().value();
-            presetSpringWidth = button->getSpringWidth();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            int temp = button->getSpringWidth();
-            if (temp != presetSpringWidth)
-            {
-                presetSpringWidth = 0;
-                iter.toBack();
-            }
+            presetSpringWidth = 0;
+            break;
         }
     }
 
@@ -421,22 +420,22 @@ int JoyDPad::getButtonsPresetSpringHeight()
     int presetSpringHeight = 0;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return presetSpringHeight;
+
+    JoyDPadButton *button = iter.value();
+    presetSpringHeight = button->getSpringHeight();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        int temp = button->getSpringHeight();
+        if (temp != presetSpringHeight)
         {
-            JoyDPadButton *button = iter.next().value();
-            presetSpringHeight = button->getSpringHeight();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            int temp = button->getSpringHeight();
-            if (temp != presetSpringHeight)
-            {
-                presetSpringHeight = 0;
-                iter.toBack();
-            }
+            presetSpringHeight = 0;
+            break;
         }
     }
 
@@ -458,22 +457,22 @@ double JoyDPad::getButtonsPresetSensitivity()
     double presetSensitivity = 1.0;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return presetSensitivity;
+
+    JoyDPadButton *button = iter.value();
+    presetSensitivity = button->getSensitivity();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        double temp = button->getSensitivity();
+        if (!qFuzzyCompare(temp, presetSensitivity))
         {
-            JoyDPadButton *button = iter.next().value();
-            presetSensitivity = button->getSensitivity();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            double temp = button->getSensitivity();
-            if (!qFuzzyCompare(temp, presetSensitivity))
-            {
-                presetSensitivity = 1.0;
-                iter.toBack();
-            }
+            presetSensitivity = 1.0;
+            break;
         }
     }
 
@@ -594,22 +593,22 @@ bool JoyDPad::isRelativeSpring()
     bool relative = false;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return relative;
+
+    JoyDPadButton *button = iter.value();
+    relative = button->isRelativeSpring();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        bool temp = button->isRelativeSpring();
+        if (temp != relative)
         {
-            JoyDPadButton *button = iter.next().value();
-            relative = button->isRelativeSpring();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            bool temp = button->isRelativeSpring();
-            if (temp != relative)
-            {
-                relative = false;
-                iter.toBack();
-            }
+            relative = false;
+            break;
         }
     }
 
@@ -896,22 +895,22 @@ double JoyDPad::getButtonsEasingDuration()
     double result = GlobalVariables::JoyButton::DEFAULTEASINGDURATION;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return result;
+
+    JoyDPadButton *button = iter.value();
+    result = button->getEasingDuration();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        double temp = button->getEasingDuration();
+        if (!qFuzzyCompare(temp, result))
         {
-            JoyDPadButton *button = iter.next().value();
-            result = button->getEasingDuration();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            double temp = button->getEasingDuration();
-            if (!qFuzzyCompare(temp, result))
-            {
-                result = GlobalVariables::JoyButton::DEFAULTEASINGDURATION;
-                iter.toBack();
-            }
+            result = GlobalVariables::JoyButton::DEFAULTEASINGDURATION;
+            break;
         }
     }
 
@@ -934,22 +933,22 @@ int JoyDPad::getButtonsSpringDeadCircleMultiplier()
     int result = GlobalVariables::JoyButton::DEFAULTSPRINGRELEASERADIUS;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return result;
+
+    JoyDPadButton *button = iter.value();
+    result = button->getSpringDeadCircleMultiplier();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        int temp = button->getSpringDeadCircleMultiplier();
+        if (temp != result)
         {
-            JoyDPadButton *button = iter.next().value();
-            result = button->getSpringDeadCircleMultiplier();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            int temp = button->getSpringDeadCircleMultiplier();
-            if (temp != result)
-            {
-                result = GlobalVariables::JoyButton::DEFAULTSPRINGRELEASERADIUS;
-                iter.toBack();
-            }
+            result = GlobalVariables::JoyButton::DEFAULTSPRINGRELEASERADIUS;
+            break;
         }
     }
 
@@ -972,22 +971,22 @@ JoyButton::JoyExtraAccelerationCurve JoyDPad::getButtonsExtraAccelerationCurve()
     JoyButton::JoyExtraAccelerationCurve result = JoyButton::LinearAccelCurve;
 
     QHash<int, JoyDPadButton *> temphash = getApplicableButtons();
-    QHashIterator<int, JoyDPadButton *> iter(temphash);
-    while (iter.hasNext())
+    auto iter = temphash.cbegin();
+
+    if (iter == temphash.cend())
+        return result;
+
+    JoyDPadButton *button = iter.value();
+    result = button->getExtraAccelerationCurve();
+
+    while (++iter != temphash.cend())
     {
-        if (!iter.hasPrevious())
+        button = iter.value();
+        JoyButton::JoyExtraAccelerationCurve temp = button->getExtraAccelerationCurve();
+        if (temp != result)
         {
-            JoyDPadButton *button = iter.next().value();
-            result = button->getExtraAccelerationCurve();
-        } else
-        {
-            JoyDPadButton *button = iter.next().value();
-            JoyButton::JoyExtraAccelerationCurve temp = button->getExtraAccelerationCurve();
-            if (temp != result)
-            {
-                result = JoyButton::LinearAccelCurve;
-                iter.toBack();
-            }
+            result = JoyButton::LinearAccelCurve;
+            break;
         }
     }
 


### PR DESCRIPTION
QHashIterator::hasPrevious() is deprecated.
Replace most Java style iterators which use hasPrevious() with STL style
iterators and move the first iteration before the loop. According to the
Qt documentation [1], this should also be more efficient.

Keep the usage of hasPrevious() for JoyButton::slotiter since it is
used in a more sophisticated way. This is also a QListIterator where
hasPrevious is not deprecated.

[1]: https://doc.qt.io/qt-5/containers.html