### PR TITLE
Fix compiler warning in JoyButton

### DIFF
--- a/src/joybutton.cpp
+++ b/src/joybutton.cpp
@@ -659,9 +659,8 @@ void JoyButton::activateMiniSlots(JoyButtonSlot *slot, JoyButtonSlot *mix)
     int tempcode = slot->getSlotCode();
     JoyButtonSlot::JoySlotInputAction mode = slot->getSlotMode();
 
-    switch (mode)
+    if (mode == JoyButtonSlot::JoyKeyboard)
     {
-    case JoyButtonSlot::JoyKeyboard: {
         sendKeybEvent(slot, true);
 
         getActiveSlotsLocal().append(slot);
@@ -679,9 +678,6 @@ void JoyButton::activateMiniSlots(JoyButtonSlot *slot, JoyButtonSlot *mix)
 
             lastActiveKey = nullptr;
         }
-
-        break;
-    }
     }
 }
 
@@ -962,6 +958,8 @@ void JoyButton::addEachSlotToActives(JoyButtonSlot *slot, int &i, bool &delaySeq
 
         break;
     }
+    default:
+        break;
     }
 }
 


### PR DESCRIPTION
In JoyButton are two switch statements which do not have cases for all
enumeration values. This causes a compiler warning.

Convert one switch to an "if" because it only has one case.
Add a default statement to the other one.
