### PR TITLE
chore: Add building with Ubuntu 22.04 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,12 @@ jobs:
             fail-fast: false
             matrix:
                 include:
+                    - name: Ubuntu 22-04 GCC
+                      image: ubuntu-22.04
+                      cc: gcc
+                      cxx: g++
+                      build-type: Debug
+                      experimental: false
                     - name: Ubuntu 20-04 GCC
                       image: ubuntu-20.04
                       cc: gcc


### PR DESCRIPTION
This one will have to wait some time: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

Blocked by: https://github.com/actions/virtual-environments/issues/5428