### PR TITLE
Fix mouse calculations for multiple mice

### DIFF
--- a/src/joybutton.cpp
+++ b/src/joybutton.cpp
@@ -3731,9 +3731,7 @@ void JoyButton::moveMouseCursor(int &movedX, int &movedY, int &movedElapsed, QLi
 void JoyButton::distanceForMovingAx(double &finalAx, mouseCursorInfo infoAx)
 {
     if (!qFuzzyIsNull(infoAx.code))
-    {
-        finalAx = (infoAx.code < 0) ? qMin(infoAx.code, finalAx) : qMax(infoAx.code, finalAx);
-    }
+        finalAx += infoAx.code;
 }
 
 void JoyButton::adjustAxForCursor(QList<double> *mouseHistoryList, double &adjustedAx, double &cursorRemainder,


### PR DESCRIPTION
Calculate mouse axis movement distance by just summing all values from
different input axes. The existing implementation with minimum and
maximum causes strange mouse "stuttering"-like movement when multiple
controller inputs are mapped to mouse movement.
This happens if both sticks are mapped as mouse and will be a major
problem with the coming sensor implementation.