### PR TITLE
Remove dead code in JoyControlStick

### DIFF
--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -906,44 +906,6 @@ void JoyControlStick::setDiagonalRange(int value)
 }
 
 /**
- * @brief Delete old stick direction buttons and create new stick direction
- *     buttons.
- */
-void JoyControlStick::refreshButtons()
-{
-    deleteButtons();
-    populateButtons();
-}
-
-/**
- * @brief Delete stick direction buttons and stick modifier button.
- *
- * (Not used by destructor because parents delete children automatically)
- */
-void JoyControlStick::deleteButtons()
-{
-    QHashIterator<JoyStickDirections, JoyControlStickButton *> iter(buttons);
-    while (iter.hasNext())
-    {
-        JoyButton *button = iter.next().value();
-
-        if (button != nullptr)
-        {
-            button->deleteLater();
-            button = nullptr;
-        }
-    }
-
-    buttons.clear();
-
-    if (modifierButton != nullptr)
-    {
-        delete modifierButton;
-        modifierButton = nullptr;
-    }
-}
-
-/**
  * @brief Take a XML stream and set the stick and direction button properties
  *     according to the values contained within the stream.
  * @param QXmlStreamReader instance that will be used to read property values.

--- a/src/joycontrolstick.h
+++ b/src/joycontrolstick.h
@@ -216,8 +216,6 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     void performButtonPress(JoyControlStickButton *eventbutton, JoyControlStickButton *&activebutton, bool ignoresets);
     void performButtonRelease(JoyControlStickButton *&eventbutton, bool ignoresets);
 
-    void refreshButtons();
-    void deleteButtons();
     void resetButtons();
 
     double calculateXDistanceFromDeadZone(bool interpolate = false); // JoyControlStickAxes class


### PR DESCRIPTION
The functions "refreshButtons" and "deleteButtons" are not used
anywhere.