### PR TITLE
Increase minimum size of ButtonEditDialog

### DIFF
--- a/src/gui/buttoneditdialog.cpp
+++ b/src/gui/buttoneditdialog.cpp
@@ -57,11 +57,6 @@ ButtonEditDialog::ButtonEditDialog(InputDevice *joystick, bool isNumKeypad, QWid
     withoutQuickSetDialog = false;
     m_isNumKeypad = isNumKeypad;
 
-    if (m_isNumKeypad)
-    {
-        setMinimumSize(844, 480);
-    }
-
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Choose your keyboard key"));
     update();
@@ -75,7 +70,6 @@ ButtonEditDialog::ButtonEditDialog(InputDevice *joystick, bool isNumKeypad, QWid
     currentset->release();
     joystick->resetButtonDownCount();
 
-    setMinimumHeight(460);
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowModality(Qt::WindowModal);
 
@@ -120,11 +114,6 @@ ButtonEditDialog::ButtonEditDialog(JoyButton *button, InputDevice *joystick, boo
     withoutQuickSetDialog = true;
     m_isNumKeypad = isNumKeypad;
 
-    if (m_isNumKeypad)
-    {
-        setMinimumSize(844, 480);
-    }
-
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Choose your keyboard key"));
     update();
@@ -138,7 +127,6 @@ ButtonEditDialog::ButtonEditDialog(JoyButton *button, InputDevice *joystick, boo
     currentset->release();
     joystick->resetButtonDownCount();
 
-    setMinimumHeight(460);
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowModality(Qt::WindowModal);
 

--- a/src/gui/buttoneditdialog.ui
+++ b/src/gui/buttoneditdialog.ui
@@ -10,13 +10,13 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>430</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>800</width>
-    <height>430</height>
+    <height>600</height>
    </size>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
On some systems it may happen that the ButtonEditDialog opens too small
so that is it unusable before resizing it manually. See screenshots below.

Screenshot without the change:
![before](https://user-images.githubusercontent.com/36964161/166156486-4c0800a6-c62f-452c-a4a9-5e3bf908e2ea.png)
Screenshot with the change:
![after](https://user-images.githubusercontent.com/36964161/166156483-ec27e9c4-4c6d-40b0-804b-0c40369b5526.png)

