### PR TITLE
Implement offset and gain stick Calibration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ set(antimicrox_SOURCES
         src/mousedialog/uihelpers/mousecontrolsticksettingsdialoghelper.cpp
         src/mousedialog/uihelpers/mousedpadsettingsdialoghelper.cpp
         src/mousehelper.cpp
+        src/pt1filter.cpp
         src/qtkeymapperbase.cpp
         src/sdleventreader.cpp
         src/setjoystick.cpp
@@ -316,6 +317,7 @@ set(antimicrox_HEADERS
         src/mousedialog/uihelpers/mousecontrolsticksettingsdialoghelper.h
         src/mousedialog/uihelpers/mousedpadsettingsdialoghelper.h
         src/mousehelper.h
+        src/pt1filter.h
         src/qtkeymapperbase.h
         src/sdleventreader.h
         src/setjoystick.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ set(antimicrox_SOURCES
         src/sdleventreader.cpp
         src/setjoystick.cpp
         src/simplekeygrabberbutton.cpp
+        src/statisticsestimator.cpp
         src/stickpushbuttongroup.cpp
         src/uihelpers/advancebuttondialoghelper.cpp
         src/uihelpers/buttoneditdialoghelper.cpp
@@ -319,6 +320,7 @@ set(antimicrox_HEADERS
         src/sdleventreader.h
         src/setjoystick.h
         src/simplekeygrabberbutton.h
+        src/statisticsestimator.h
         src/stickpushbuttongroup.h
         src/uihelpers/advancebuttondialoghelper.h
         src/uihelpers/buttoneditdialoghelper.h

--- a/src/axisvaluebox.cpp
+++ b/src/axisvaluebox.cpp
@@ -106,10 +106,10 @@ void AxisValueBox::setValue(JoyAxis *axis, int value)
     qDebug() << "Value for axis from value box at start is: " << value;
     qDebug() << "throttle variable has value: " << m_throttle;
 
-    if ((value >= axis->getAxisMinCal()) && (value <= axis->getAxisMaxCal()))
+    if ((value >= GlobalVariables::JoyAxis::AXISMIN) && (value <= GlobalVariables::JoyAxis::AXISMAX))
     {
-        qDebug() << "Value for axis from value box is between : " << axis->getAxisMinCal() << " and "
-                 << axis->getAxisMaxCal();
+        qDebug() << "Value for axis from value box is between : " << GlobalVariables::JoyAxis::AXISMIN << " and "
+                 << GlobalVariables::JoyAxis::AXISMAX;
 
         switch (m_throttle)
         {
@@ -118,7 +118,7 @@ void AxisValueBox::setValue(JoyAxis *axis, int value)
             break;
 
         case -1:
-            this->joyValue = ((value + axis->getAxisMinCal()) / 2);
+            this->joyValue = ((value + GlobalVariables::JoyAxis::AXISMIN) / 2);
             break;
 
         case 0:
@@ -126,7 +126,7 @@ void AxisValueBox::setValue(JoyAxis *axis, int value)
             break;
 
         case 1:
-            this->joyValue = (value + axis->getAxisMaxCal()) / 2;
+            this->joyValue = (value + GlobalVariables::JoyAxis::AXISMAX) / 2;
             break;
 
         case 2:
@@ -152,7 +152,7 @@ void AxisValueBox::setDeadZone(JoyAxis *axis, int deadZone)
 {
     m_axis = axis;
 
-    if ((deadZone >= axis->getAxisMinCal()) && (deadZone <= axis->getAxisMaxCal()))
+    if ((deadZone >= GlobalVariables::JoyAxis::AXISMIN) && (deadZone <= GlobalVariables::JoyAxis::AXISMAX))
     {
         m_deadZone = deadZone;
     }
@@ -176,7 +176,7 @@ void AxisValueBox::setMaxZone(JoyAxis *axis, int maxZone)
 {
     m_axis = axis;
 
-    if ((maxZone >= axis->getAxisMinCal()) && (maxZone <= axis->getAxisMaxCal()))
+    if ((maxZone >= GlobalVariables::JoyAxis::AXISMIN) && (maxZone <= GlobalVariables::JoyAxis::AXISMAX))
     {
         m_maxZone = maxZone;
     }
@@ -285,20 +285,6 @@ void AxisValueBox::paintEvent(QPaintEvent *event)
     }
 }
 
-int AxisValueBox::getMaxAxValue()
-{
-    bool axisDefined = false;
-    if (m_axis != nullptr)
-        axisDefined = true;
+int AxisValueBox::getMaxAxValue() { return GlobalVariables::JoyAxis::AXISMAX; }
 
-    return (axisDefined && (m_axis->getAxisMaxCal() != -1)) ? m_axis->getAxisMaxCal() : GlobalVariables::JoyAxis::AXISMAX;
-}
-
-int AxisValueBox::getMinAxValue()
-{
-    bool axisDefined = false;
-    if (m_axis != nullptr)
-        axisDefined = true;
-
-    return (axisDefined && (m_axis->getAxisMinCal() != -1)) ? m_axis->getAxisMinCal() : GlobalVariables::JoyAxis::AXISMIN;
-}
+int AxisValueBox::getMinAxValue() { return GlobalVariables::JoyAxis::AXISMIN; }

--- a/src/gui/axiseditdialog.cpp
+++ b/src/gui/axiseditdialog.cpp
@@ -335,7 +335,7 @@ void AxisEditDialog::updateDeadZoneSlider(QString value)
 {
     int temp = value.toInt();
 
-    if ((temp >= m_axis->getAxisMinCal()) && (temp <= m_axis->getAxisMaxCal()))
+    if ((temp >= GlobalVariables::JoyAxis::AXISMIN) && (temp <= GlobalVariables::JoyAxis::AXISMAX))
     {
         ui->horizontalSlider->setValue(temp);
     }
@@ -345,7 +345,7 @@ void AxisEditDialog::updateMaxZoneSlider(QString value)
 {
     int temp = value.toInt();
 
-    if ((temp >= m_axis->getAxisMinCal()) && (temp <= m_axis->getAxisMaxCal()))
+    if ((temp >= GlobalVariables::JoyAxis::AXISMIN) && (temp <= GlobalVariables::JoyAxis::AXISMAX))
     {
         ui->horizontalSlider_2->setValue(temp);
     }

--- a/src/gui/calibration.cpp
+++ b/src/gui/calibration.cpp
@@ -1,5 +1,6 @@
 /* antimicrox Gamepad to KB+M event mapper
  * Copyright (C) 2020 Jagoda Górska <juliagoda.pl@protonmail.com>
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,722 +21,516 @@
 
 #include "globalvariables.h"
 #include "inputdevice.h"
-#include "joybuttontypes/joycontrolstickmodifierbutton.h"
 #include "joycontrolstick.h"
-#include "joytabwidget.h"
 
-#include <SDL2/SDL_joystick.h>
-
+#include <QCloseEvent>
 #include <QDebug>
-#include <QFuture>
-#include <QLayoutItem>
 #include <QMessageBox>
-#include <QPointer>
-#include <QProgressBar>
-#include <QTabWidget>
-#include <QtConcurrent>
+
+const int Calibration::CAL_MIN_SAMPLES = 10;
+// Use squared accuracy to avoid root calculation. 1e-4 corresponds to an accuracy of 1%.
+const double Calibration::CAL_ACCURACY_SQ = 1e-4;
+const double Calibration::STICK_CAL_TAU = 0.045;
+const int Calibration::STICK_RATE_SAMPLES = 100;
+const int Calibration::CAL_TIMEOUT = 30;
 
 Calibration::Calibration(InputDevice *joystick, QWidget *parent)
-    : QWidget(parent)
-    , ui(new Ui::Calibration)
-    , currentJoystick(joystick)
-    , helper(currentJoystick->getActiveSetJoystick()->getJoyStick(0))
+    : QDialog(parent)
+    , m_ui(new Ui::Calibration)
+    , m_type(CAL_NONE)
+    , m_calibrated(false)
+    , m_changed(false)
+    , m_joystick(joystick)
 {
-    ui->setupUi(this);
+    m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose, true);
     setWindowTitle(tr("Calibration"));
+    hideCalibrationData();
 
-    sumX = 0;
-    sumY = 0;
+    int device_count = 0;
 
-    center_calibrated_x = 0;
-    center_calibrated_y = 0;
-
-    deadzone_calibrated_x = 0;
-    deadzone_calibrated_y = 0;
-
-    max_axis_val_x = 0;
-    min_axis_val_x = 0;
-
-    max_axis_val_y = 0;
-    min_axis_val_y = 0;
-
-    calibrated = false;
-
-    QPointer<JoyControlStick> controlstick = currentJoystick->getActiveSetJoystick()->getJoyStick(0);
-    this->stick = controlstick.data();
-
-    ui->resetBtn->setEnabled(calibrated);
-    ui->saveBtn->setEnabled(false);
-
-    controlstick.data()->getModifierButton()->establishPropertyUpdatedConnections();
-    helper.moveToThread(controlstick.data()->thread());
-
-    setProgressBars(0, 0);
-    ui->stickStatusBoxWidget->setFocus();
-    ui->stickStatusBoxWidget->setStick(controlstick.data());
-    ui->stickStatusBoxWidget->update();
-
-    if (controlstick.isNull())
-        controlstick.clear();
-
-    QList<JoyControlStick *> sticksList = currentJoystick->getActiveSetJoystick()->getSticks().values();
-    QListIterator<JoyControlStick *> currStick(sticksList);
-
-    while (currStick.hasNext())
+    QMap<QString, int> dropdown_sticks;
+    QHash<int, JoyControlStick *> sticks = m_joystick->getActiveSetJoystick()->getSticks();
+    for (auto iter = sticks.cbegin(); iter != sticks.cend(); ++iter)
     {
-        ui->axesBox->addItem(currStick.next()->getPartialName());
+        dropdown_sticks.insert(iter.value()->getPartialName(), CAL_STICK | (iter.key() << CAL_INDEX_POS));
     }
 
-    connect(currentJoystick, &InputDevice::destroyed, this, &Calibration::close);
-    connect(ui->saveBtn, &QPushButton::clicked, this, &Calibration::saveSettings);
-    connect(ui->cancelBtn, &QPushButton::clicked, this, &Calibration::close);
-    connect(ui->axesBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            &Calibration::createAxesConnection);
-    connect(ui->startButton, &QPushButton::clicked, this, &Calibration::startCalibration);
-    connect(ui->resetBtn, &QPushButton::clicked, [this](bool clicked) { resetSettings(false, clicked); });
+    for (auto iter = dropdown_sticks.cbegin(); iter != dropdown_sticks.cend(); ++iter)
+    {
+        m_ui->deviceComboBox->addItem(iter.key(), QVariant(int(iter.value())));
+        ++device_count;
+    }
+
+    connect(m_joystick, &InputDevice::destroyed, this, &Calibration::close);
+    connect(m_ui->resetBtn, &QPushButton::clicked, this, &Calibration::resetSettings);
+    connect(m_ui->saveBtn, &QPushButton::clicked, this, &Calibration::saveSettings);
+    connect(m_ui->cancelBtn, &QPushButton::clicked, this, &Calibration::close);
+    connect(m_ui->deviceComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &Calibration::deviceSelectionChanged);
+
+    if (device_count == 0)
+    {
+        m_ui->steps->setText(tr("Selected device doesn't have any inputs to calibrate."));
+    } else
+    {
+        int index = m_ui->deviceComboBox->currentIndex();
+        unsigned int data = m_ui->deviceComboBox->itemData(index).toInt();
+        selectTypeIndex(data);
+    }
 
     update();
 }
 
-Calibration::~Calibration() { delete ui; }
+Calibration::~Calibration() { delete m_ui; }
 
 /**
- * @brief Resets memory of all variables to default, updates window and shows message
- * @return Nothing
+ * @brief Ask for confirmation when the dialog is closed with unsafed changed.
  */
-void Calibration::resetSettings(bool silentReset, bool)
+void Calibration::closeEvent(QCloseEvent *event)
 {
-    if (!silentReset)
+    event->ignore();
+    if (m_changed)
     {
-        QMessageBox msgBox;
-        msgBox.setText(tr("Do you really want to reset settings of current axis?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-
-        switch (msgBox.exec())
+        if (askConfirmation(tr("Calibration was not saved for the preset. Do you really want to continue?"), false))
         {
-        case QMessageBox::Yes:
-            restoreCalValues();
-            ui->steps->clear();
-            break;
-
-        case QMessageBox::No:
-            break;
-
-        default:
-            break;
+            event->accept();
         }
     } else
     {
-        restoreCalValues();
-        ui->steps->clear();
+        event->accept();
     }
 }
 
-void Calibration::restoreCalValues()
+/**
+ * @brief Asks for confirmation and resets calibration values of the selected device
+ *  afterwards.
+ */
+void Calibration::resetSettings()
 {
-    sumX = 0;
-    sumY = 0;
+    QMessageBox msgBox;
+    msgBox.setText(tr("Do you really want to reset calibration of current device?"));
+    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 
-    center_calibrated_x = 0;
-    center_calibrated_y = 0;
-    deadzone_calibrated_x = 0;
-    deadzone_calibrated_y = 0;
+    switch (msgBox.exec())
+    {
+    case QMessageBox::Yes:
+        resetCalibrationValues();
+        m_ui->steps->clear();
+        break;
 
-    max_axis_val_x = 0;
-    min_axis_val_x = 0;
-    max_axis_val_y = 0;
-    min_axis_val_y = 0;
+    case QMessageBox::No:
+        break;
 
-    x_es_val.clear();
-    y_es_val.clear();
+    default:
+        break;
+    }
+}
 
-    joyAxisX->setDeadZone(GlobalVariables::JoyAxis::AXISDEADZONE);
-    joyAxisY->setDeadZone(GlobalVariables::JoyAxis::AXISDEADZONE);
+/**
+ * @brief Shows the stick offset and gain calibration values to the user.
+ */
+void Calibration::showStickCalibrationValues(bool offsetXvalid, double offsetX, bool gainXvalid, double gainX,
+                                             bool offsetYvalid, double offsetY, bool gainYvalid, double gainY)
+{
+    QPalette paletteBlack = m_ui->offsetXValue->palette();
+    paletteBlack.setColor(m_ui->offsetXValue->foregroundRole(), Qt::black);
+    QPalette paletteRed = m_ui->offsetXValue->palette();
+    paletteRed.setColor(m_ui->offsetXValue->foregroundRole(), Qt::red);
 
-    joyAxisX->setMaxZoneValue(GlobalVariables::JoyAxis::AXISMAXZONE);
-    joyAxisY->setMaxZoneValue(GlobalVariables::JoyAxis::AXISMAXZONE);
+    m_ui->offsetXValue->setPalette(offsetXvalid ? paletteBlack : paletteRed);
+    m_ui->gainXValue->setPalette(gainXvalid ? paletteBlack : paletteRed);
+    m_ui->offsetYValue->setPalette(offsetYvalid ? paletteBlack : paletteRed);
+    m_ui->gainYValue->setPalette(gainYvalid ? paletteBlack : paletteRed);
 
-    stick->setDeadZone(GlobalVariables::JoyAxis::AXISDEADZONE);
-    stick->setMaxZone(GlobalVariables::JoyAxis::AXISMAXZONE);
+    m_ui->offsetXValue->setText(QString::number(offsetX));
+    m_ui->gainXValue->setText(QString::number(gainX));
+    m_ui->offsetYValue->setText(QString::number(offsetY));
+    m_ui->gainYValue->setText(QString::number(gainY));
+}
 
-    ui->Information->clear();
+/**
+ * @brief hides all calibration values and their labels.
+ */
+void Calibration::hideCalibrationData()
+{
+    m_ui->xAxisLabel->setVisible(false);
+    m_ui->yAxisLabel->setVisible(false);
+    m_ui->zAxisLabel->setVisible(false);
+    m_ui->offsetXLabel->setVisible(false);
+    m_ui->offsetYLabel->setVisible(false);
+    m_ui->offsetZLabel->setVisible(false);
+    m_ui->offsetXValue->setVisible(false);
+    m_ui->offsetYValue->setVisible(false);
+    m_ui->offsetZValue->setVisible(false);
+    m_ui->gainXLabel->setVisible(false);
+    m_ui->gainYLabel->setVisible(false);
+    m_ui->gainZLabel->setVisible(false);
+    m_ui->gainXValue->setVisible(false);
+    m_ui->gainYValue->setVisible(false);
+    m_ui->gainZValue->setVisible(false);
+    m_ui->steps->clear();
+}
 
-    calibrated = false;
+/**
+ * @brief Prepares calibration for the selected device type.
+ *  Show all used values and labels and connect buttons to the corresponding
+ *  event handlers.
+ */
+void Calibration::selectTypeIndex(unsigned int type_index)
+{
+    CalibrationType type = static_cast<CalibrationType>(type_index & CAL_TYPE_MASK);
+    unsigned int index = (type_index & CAL_INDEX_MASK) >> CAL_INDEX_POS;
 
-    ui->saveBtn->setEnabled(false);
-    ui->resetBtn->setEnabled(false);
-    ui->stickStatusBoxWidget->update();
+    if (m_type == type && m_index == index)
+        return;
 
+    disconnect(m_ui->startBtn, &QPushButton::clicked, this, nullptr);
+    m_type = type;
+    m_index = index;
+    m_changed = false;
+    hideCalibrationData();
+
+    if (m_type == CAL_STICK)
+    {
+        m_ui->statusStack->setCurrentIndex(1);
+        m_stick = m_joystick->getActiveSetJoystick()->getSticks().value(m_index);
+        m_calibrated = m_stick->isCalibrated();
+
+        if (m_calibrated)
+        {
+            double offsetX, gainX, offsetY, gainY;
+            m_stick->getCalibration(&offsetX, &gainX, &offsetY, &gainY);
+            showStickCalibrationValues(true, offsetX, true, gainX, true, offsetY, true, gainY);
+        } else
+        {
+            showStickCalibrationValues(false, 0.0, false, 1.0, false, 0.0, false, 1.0);
+        }
+
+        m_ui->xAxisLabel->setVisible(true);
+        m_ui->yAxisLabel->setVisible(true);
+        m_ui->offsetXLabel->setVisible(true);
+        m_ui->offsetYLabel->setVisible(true);
+        m_ui->offsetXValue->setVisible(true);
+        m_ui->offsetYValue->setVisible(true);
+        m_ui->gainXLabel->setVisible(true);
+        m_ui->gainYLabel->setVisible(true);
+        m_ui->gainXValue->setVisible(true);
+        m_ui->gainYValue->setVisible(true);
+
+        m_ui->resetBtn->setEnabled(m_calibrated);
+        m_ui->saveBtn->setEnabled(false);
+
+        m_ui->stickStatusBoxWidget->setFocus();
+        m_ui->stickStatusBoxWidget->setStick(m_stick);
+        m_ui->stickStatusBoxWidget->update();
+
+        connect(m_ui->startBtn, &QPushButton::clicked, this, &Calibration::startStickOffsetCalibration);
+        m_ui->startBtn->setEnabled(true);
+        m_ui->resetBtn->setEnabled(true);
+    }
+}
+
+/**
+ * @brief Performs linear regression on the measurement values of one axis to
+ *  determine offset and gain.
+ * @param[out] offset The calculated offset.
+ * @param[out] gain The calculated gain.
+ * @param[in] xoffset The measured X value at the point (x, 0)
+ * @param[in] xmin The measured X value at the point (x, AXISMIN)
+ * @param[in] xmax The measured X value at the point (x, AXISMAX)
+ *
+ * Since the sum (AXISMIN + 0 + AXISMAX) is 0, the calculation below could
+ *  be simplified.
+ */
+void Calibration::stickRegression(double *offset, double *gain, double xoffset, double xmin, double xmax)
+{
+    double ymin = GlobalVariables::JoyAxis::AXISMIN;
+    double ymax = GlobalVariables::JoyAxis::AXISMAX;
+
+    double sum_X = xoffset + xmin + xmax;
+    double sum_X2 = xoffset * xoffset + xmin * xmin + xmax * xmax;
+    double sum_XY = xmin * ymin + xmax * ymax;
+
+    *offset = (-sum_X * sum_XY) / (3 * sum_X2 - sum_X * sum_X);
+    *gain = 3 * sum_XY / (3 * sum_X2 - sum_X * sum_X);
+}
+
+/**
+ * @brief Resets calibration values of the currently selected device and
+ *  updates UI.
+ */
+void Calibration::resetCalibrationValues()
+{
+    if (m_type == CAL_STICK && m_stick != nullptr)
+    {
+        m_stick->resetCalibration();
+        m_calibrated = false;
+
+        m_ui->saveBtn->setEnabled(false);
+        m_ui->resetBtn->setEnabled(false);
+        m_ui->stickStatusBoxWidget->update();
+        showStickCalibrationValues(false, 0, false, 0, false, 0, false, 0);
+    }
     update();
 }
 
 /**
- * @brief Creates quadratic field in a case, when max value is not equal to negative min value. It always chooses less value
- * @param max value for X - positive value
- * @param min value for X - negative value
- * @param max value for Y - positive value
- * @param min value for Y - negative value
- * @return Nothing
+ * @brief Asks the user for confirmation with a given message if the given
+ *  condition is false.
+ * @param[in] message The message to show.
+ * @param[in] confirmed True, if the action is already confirmed or no confirmation is necessary.
+ * @returns True, if the action was confirmed. False otherwise.
  */
-void Calibration::setQuadraticZoneCalibrated(int &max_axis_val_x, int &min_axis_val_x, int &max_axis_val_y,
-                                             int &min_axis_val_y)
+bool Calibration::askConfirmation(QString message, bool confirmed)
 {
-    if (max_axis_val_x > abs(min_axis_val_x))
-        max_axis_val_x = abs(min_axis_val_x);
-    else
-        min_axis_val_x = -(max_axis_val_x);
-
-    if (max_axis_val_y > abs(min_axis_val_y))
-        max_axis_val_y = abs(min_axis_val_y);
-    else
-        min_axis_val_y = -(max_axis_val_y);
-}
-
-/**
- * @brief Moves deadzone position after changing center position of axes
- * @return Moved deadzone position
- */
-int Calibration::calibratedDeadZone(int center, int deadzone) { return (center + deadzone); }
-
-int Calibration::fakeMapFunc(const int &x) { return x; }
-
-void Calibration::summarizeValues(int &numbFromList, const int &mappednumb) { numbFromList += mappednumb; }
-
-void Calibration::getMinVal(int &numbFromList, const int &mappednumb)
-{
-    if (numbFromList > mappednumb)
-        numbFromList = mappednumb;
-}
-
-void Calibration::getMaxVal(int &numbFromList, const int &mappednumb)
-{
-    if (numbFromList < mappednumb)
-        numbFromList = mappednumb;
-}
-
-/**
- * @brief Prepares first step of calibration - finding center
- * @return nothing
- */
-void Calibration::startCalibration()
-{
-    bool confirmed = true;
-
-    if (false)
+    if (!confirmed)
     {
         QMessageBox msgBox;
-        msgBox.setText(tr("Calibration was saved for the preset. Do you really want to reset settings?"));
+        msgBox.setText(message);
         msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
 
         switch (msgBox.exec())
         {
         case QMessageBox::Ok:
-            confirmed = true;
-            ui->resetBtn->setEnabled(false);
-            break;
+            return true;
 
         case QMessageBox::Cancel:
-            confirmed = false;
-            break;
+            return false;
 
         default:
-            confirmed = true;
-            break;
+            return true;
         }
+    }
+    return true;
+}
+
+/**
+ * @brief Device change event handler. Asks for confirmation if there are unsaved changes.
+ */
+void Calibration::deviceSelectionChanged(int index)
+{
+    if (askConfirmation(tr("Calibration was not saved for the preset. Do you really want to continue?"), !m_changed))
+    {
+        int data = m_ui->deviceComboBox->itemData(index).toInt();
+        selectTypeIndex(data);
     } else
     {
-        center_calibrated_x = 0;
-        center_calibrated_y = 0;
-        deadzone_calibrated_x = 0;
-        deadzone_calibrated_y = 0;
-
-        min_axis_val_x = 0;
-        min_axis_val_y = 0;
-        max_axis_val_x = 0;
-        max_axis_val_y = 0;
-
-        x_es_val.clear();
-        y_es_val.clear();
-    }
-
-    if ((joyAxisX != nullptr) && (joyAxisY != nullptr) && confirmed)
-    {
-        center_calibrated_x = 0;
-        center_calibrated_y = 0;
-        deadzone_calibrated_x = 0;
-        deadzone_calibrated_y = 0;
-
-        min_axis_val_x = 0;
-        min_axis_val_y = 0;
-        max_axis_val_x = 0;
-        max_axis_val_y = 0;
-
-        x_es_val.clear();
-        y_es_val.clear();
-
-        calibrated = false;
-
-        ui->steps->setText(tr("Place the joystick in the center position.\n\nIt's the part, where often you don't have to "
-                              "move. Just skip it in such situation."));
-        this->setWindowTitle(tr("Calibrating center"));
-        ui->startButton->setText(tr("Start second step"));
-        update();
-
-        QList<int> xValues = x_es_val.values();
-        QFuture<int> resX = QtConcurrent::mappedReduced(xValues, &Calibration::fakeMapFunc, &Calibration::summarizeValues);
-        sumX = resX.result();
-
-        QList<int> yValues = x_es_val.values();
-        QFuture<int> resY = QtConcurrent::mappedReduced(yValues, &Calibration::fakeMapFunc, &Calibration::summarizeValues);
-        sumY = resY.result();
-
-        if ((sumX != 0) && (sumY != 0))
-        {
-            center_calibrated_x = sumX / x_es_val.count();
-            center_calibrated_y = sumY / y_es_val.count();
-
-        } else
-        {
-            center_calibrated_x = 0;
-            center_calibrated_y = 0;
-        }
-
-        QString text = QString();
-        text.append(tr("\n\nCenter X: %1").arg(center_calibrated_x));
-        text.append(tr("\nCenter Y: %1").arg(center_calibrated_y));
-        ui->Information->setText(text);
-        this->text = text;
-
-        x_es_val.clear();
-        y_es_val.clear();
-        sumX = 0;
-        sumY = 0;
-
-        update();
-        disconnect(ui->startButton, &QPushButton::clicked, this, nullptr);
-        connect(ui->startButton, &QPushButton::clicked, this, &Calibration::startSecondStep);
+        int index = m_ui->deviceComboBox->findData(QVariant(m_type | (m_index << CAL_INDEX_POS)));
+        m_ui->deviceComboBox->blockSignals(true);
+        m_ui->deviceComboBox->setCurrentIndex(index);
+        m_ui->deviceComboBox->blockSignals(false);
     }
 }
 
 /**
- * @brief Prepares second step of calibration - moving into top-left corner - negative values
- * @return nothing
+ * @brief Stick data event handler. Performs stick offset estimation
+ *  and stops itself if the value was found or the process timed out.
+ *
+ * At the beginning, it waits for the first stick moved event and calculates
+ *  the event rate for the denoise lag filter.
+ * Then it looks for local minima and maxima within the sticks dead zone
+ *  which are used to estimate the sticks center position.
  */
-void Calibration::startSecondStep()
+void Calibration::onStickOffsetData(int x, int y)
 {
-    if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
+    if (m_phase == 0)
     {
-        ui->steps->setText(tr("\nPlace the joystick in the top-left corner many times"));
-        this->setWindowTitle(tr("Calibrating position"));
-        update();
-
-        qDebug() << "X_ES_VAL: " << x_es_val.count(QString("-"));
-        qDebug() << "Y_ES_VAL: " << y_es_val.count(QString("-"));
-
-        if (enoughProb(x_es_val.count(QString("-")), y_es_val.count(QString("-")), QString("-")))
+        m_rate_timer.start();
+        m_sample_count = 0;
+        m_phase = 1;
+    } else if (m_phase == 1)
+    {
+        if (++m_sample_count == STICK_RATE_SAMPLES)
         {
-            int min_x = 0;
-            int min_y = 0;
-
-            QList<int> xValues = x_es_val.values(QString("-"));
-            QFuture<int> resX = QtConcurrent::mappedReduced(xValues, &Calibration::fakeMapFunc, &Calibration::getMinVal);
-            min_x = resX.result();
-
-            QList<int> yValues = y_es_val.values(QString("-"));
-            QFuture<int> resY = QtConcurrent::mappedReduced(yValues, &Calibration::fakeMapFunc, &Calibration::getMinVal);
-            min_y = resY.result();
-
-            min_axis_val_x = min_x;
-            min_axis_val_y = min_y;
-
-            QString text = ui->Information->text();
-            text.append(tr("\n\nX: %1").arg(min_axis_val_x));
-            text.append(tr("\nY: %1").arg(min_axis_val_y));
-            ui->Information->setText(text);
-            this->text = text;
-
-            x_es_val.clear();
-            y_es_val.clear();
-            sumX = 0;
-            sumY = 0;
-
-            update();
-            disconnect(ui->startButton, &QPushButton::clicked, this, nullptr);
-            connect(ui->startButton, &QPushButton::clicked, this, &Calibration::startLastStep);
+            int delta_t = m_rate_timer.elapsed();
+            m_rate_timer.invalidate();
+            m_filter[0] = PT1Filter(STICK_CAL_TAU, STICK_RATE_SAMPLES * 1000.0 / delta_t);
+            m_filter[1] = PT1Filter(STICK_CAL_TAU, STICK_RATE_SAMPLES * 1000.0 / delta_t);
+            m_sample_count = 0;
+            m_end_time = QDateTime::currentDateTime().addSecs(CAL_TIMEOUT);
+            m_phase = 2;
         }
+    } else if (m_phase == 2)
+    {
+        double slopex = m_filter[0].getValue() - m_filter[0].process(x);
+        double slopey = m_filter[1].getValue() - m_filter[1].process(y);
+
+        if (((m_last_slope[0] < 0 && slopex > 0) || (m_last_slope[0] > 0 && slopex < 0)) && abs(x) < m_stick->getDeadZone())
+        {
+            m_offset[0].process(x);
+        }
+        if (((m_last_slope[1] < 0 && slopey > 0) || (m_last_slope[1] > 0 && slopey < 0)) && abs(y) < m_stick->getDeadZone())
+        {
+            m_offset[1].process(y);
+        }
+
+        // There are two move events generated for every hardware event,
+        // one updates the X the other the Y value. This causes every second
+        // derivate value to be zero. Ignore those values to get the real derivative.
+        if (slopex != 0)
+            m_last_slope[0] = slopex;
+        if (slopey != 0)
+            m_last_slope[1] = slopey;
+
+        bool xvalid = m_offset[0].calculateRelativeErrorSq() < CAL_ACCURACY_SQ && m_offset[0].getCount() > CAL_MIN_SAMPLES;
+        bool yvalid = m_offset[1].calculateRelativeErrorSq() < CAL_ACCURACY_SQ && m_offset[1].getCount() > CAL_MIN_SAMPLES;
+
+        showStickCalibrationValues(xvalid, m_offset[0].getMean(), false, 1, yvalid, m_offset[1].getMean(), false, 1);
+
+        if ((xvalid && yvalid) || QDateTime::currentDateTime() > m_end_time)
+            m_phase = 3;
+    } else if (m_phase == 3)
+    {
+        disconnect(m_stick, &JoyControlStick::moved, this, &Calibration::onStickOffsetData);
+        m_ui->steps->setText(
+            tr("Offset calibration completed. Click \"Continue calibration\" to continue with gain calibration."));
+        m_ui->startBtn->setEnabled(true);
+        update();
     }
 }
 
 /**
- * @brief Prepares third step of calibration - moving into bottom-right corner - postive values
- * @return nothing
+ * @brief Stick data event handler. Performs stick gain estimation
+ *  and stops itself if the value was found or the process timed out.
+ *
+ * It looks for local minima and maxima outside the sticks dead zone
+ *  which are used to estimate the sticks minimum and maximum position.
  */
-void Calibration::startLastStep()
+void Calibration::onStickGainData(int x, int y)
 {
-    if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
+    double slopex = m_filter[0].getValue() - m_filter[0].process(x);
+    double slopey = m_filter[1].getValue() - m_filter[1].process(y);
+
+    if (m_last_slope[0] > 0 && slopex < 0 && m_filter[0].getValue() < -m_stick->getDeadZone())
     {
-        ui->steps->setText(tr("\nPlace the joystick in the bottom-right corner"));
-        this->setWindowTitle(tr("Calibrating position"));
-        ui->startButton->setText(tr("Start final step"));
+        m_min[0].process(m_filter[0].getValue());
+    } else if (m_last_slope[0] < 0 && slopex > 0 && m_filter[0].getValue() > m_stick->getDeadZone())
+    {
+        m_max[0].process(m_filter[0].getValue());
+    }
+
+    if (m_last_slope[1] > 0 && slopey < 0 && m_filter[1].getValue() < -m_stick->getDeadZone())
+    {
+        m_min[1].process(m_filter[1].getValue());
+    } else if (m_last_slope[1] < 0 && slopey > 0 && m_filter[1].getValue() > m_stick->getDeadZone())
+    {
+        m_max[1].process(m_filter[1].getValue());
+    }
+
+    // There are two move events generated for every hardware event,
+    // one updates the X the other the Y value. This causes every second
+    // derivate value to be zero. Ignore those values to get the real derivative.
+    if (slopex != 0)
+        m_last_slope[0] = slopex;
+    if (slopey != 0)
+        m_last_slope[1] = slopey;
+
+    bool xvalid = m_min[0].calculateRelativeErrorSq() < CAL_ACCURACY_SQ && m_min[0].getCount() > CAL_MIN_SAMPLES &&
+                  m_max[0].calculateRelativeErrorSq() < CAL_ACCURACY_SQ && m_max[0].getCount() > CAL_MIN_SAMPLES;
+    bool yvalid = m_min[1].calculateRelativeErrorSq() < CAL_ACCURACY_SQ && m_min[1].getCount() > CAL_MIN_SAMPLES &&
+                  m_max[1].calculateRelativeErrorSq() < CAL_ACCURACY_SQ && m_max[1].getCount() > CAL_MIN_SAMPLES;
+
+    double offsetX, gainX, offsetY, gainY;
+    stickRegression(&offsetX, &gainX, m_offset[0].getMean(), m_min[0].getMean(), m_max[0].getMean());
+    stickRegression(&offsetY, &gainY, m_offset[1].getMean(), m_min[1].getMean(), m_max[1].getMean());
+    showStickCalibrationValues(true, offsetX, xvalid, gainX, true, offsetY, yvalid, gainY);
+
+    if ((xvalid && yvalid) || QDateTime::currentDateTime() > m_end_time)
+    {
+        m_changed = true;
+        disconnect(m_stick, &JoyControlStick::moved, this, &Calibration::onStickGainData);
+        disconnect(m_ui->startBtn, &QPushButton::clicked, this, nullptr);
+        connect(m_ui->startBtn, &QPushButton::clicked, this, &Calibration::startStickOffsetCalibration);
+        m_ui->steps->setText("Calibration completed.");
+        m_ui->startBtn->setText(tr("Start calibration"));
+        m_ui->startBtn->setEnabled(true);
+        m_ui->saveBtn->setEnabled(true);
+        m_ui->deviceComboBox->setEnabled(true);
         update();
-
-        if (enoughProb(x_es_val.count(QString("+")), y_es_val.count(QString("+")), QString("+")))
-        {
-            int max_x = 0;
-            int max_y = 0;
-
-            QList<int> xValues = x_es_val.values(QString("+"));
-            QFuture<int> resX = QtConcurrent::mappedReduced(xValues, &Calibration::fakeMapFunc, &Calibration::getMaxVal);
-            max_x = resX.result();
-
-            QList<int> yValues = y_es_val.values(QString("+"));
-            QFuture<int> resY = QtConcurrent::mappedReduced(yValues, &Calibration::fakeMapFunc, &Calibration::getMaxVal);
-            max_y = resY.result();
-
-            max_axis_val_x = max_x;
-            max_axis_val_y = max_y;
-
-            QString text2 = ui->Information->text();
-            text2.append(tr("\n\nX: %1").arg(max_axis_val_x));
-            text2.append(tr("\nY: %1").arg(max_axis_val_y));
-            ui->Information->setText(text2);
-            this->text = text2;
-            update();
-
-            setQuadraticZoneCalibrated(max_axis_val_x, min_axis_val_x, max_axis_val_y, min_axis_val_y);
-
-            deadzone_calibrated_x = (max_axis_val_y + max_axis_val_x) / 4;
-            deadzone_calibrated_y = (max_axis_val_y + max_axis_val_x) / 4;
-
-            QString text3 = ui->Information->text();
-            text3.append(tr("\n\nrange X: %1 - %2").arg(min_axis_val_x).arg(max_axis_val_x));
-            text3.append(tr("\nrange Y: %1 - %2").arg(min_axis_val_y).arg(max_axis_val_y));
-            text3.append(tr("\n\ndeadzone X: %1").arg(deadzone_calibrated_x));
-            text3.append(tr("\ndeadzone Y: %1").arg(deadzone_calibrated_y));
-            ui->Information->setText(text3);
-            this->text = text3;
-
-            if (stick != nullptr)
-            {
-                ui->saveBtn->setEnabled(true);
-            }
-
-            ui->steps->setText(tr("\n---Calibration done!---\n"));
-            ui->startButton->setText(tr("Start calibration"));
-            this->setWindowTitle(tr("Calibration"));
-            update();
-
-            x_es_val.clear();
-            y_es_val.clear();
-            sumX = 0;
-            sumY = 0;
-
-            disconnect(ui->startButton, &QPushButton::clicked, this, nullptr);
-            connect(ui->startButton, &QPushButton::clicked, this, &Calibration::startCalibration);
-        }
     }
 }
 
 /**
- * @brief Updates variables contents and shows message
- * @return nothing
+ * @brief Save calibration values into the device object.
  */
 void Calibration::saveSettings()
 {
-    if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
+    if (m_type == CAL_STICK)
     {
-        ui->resetBtn->setEnabled(true);
-        ui->saveBtn->setEnabled(false);
+        double offsetX, gainX, offsetY, gainY;
+        stickRegression(&offsetX, &gainX, m_offset[0].getMean(), m_min[0].getMean(), m_max[0].getMean());
+        stickRegression(&offsetY, &gainY, m_offset[1].getMean(), m_min[1].getMean(), m_max[1].getMean());
 
-        ui->stickStatusBoxWidget->update();
+        m_joystick->applyStickCalibration(m_index, offsetX, gainX, offsetY, gainY);
+        showStickCalibrationValues(true, offsetX, true, gainX, true, offsetY, true, gainY);
+    }
+    m_changed = false;
+    m_calibrated = true;
+    m_ui->saveBtn->setEnabled(false);
+    m_ui->resetBtn->setEnabled(true);
+}
+
+/**
+ * @brief Shows user instructions for gyroscope calibration and initializes estimators.
+ */
+void Calibration::startStickOffsetCalibration()
+{
+    if (m_stick == nullptr)
+        return;
+
+    if (askConfirmation(tr("Calibration was saved for the preset. Do you really want to reset settings?"), !m_calibrated))
+    {
+        m_offset[0].reset();
+        m_offset[1].reset();
+        m_last_slope[0] = 0;
+        m_last_slope[1] = 0;
+
+        m_stick->resetCalibration();
+        m_calibrated = false;
+        m_phase = 0;
+
+        m_ui->steps->setText(
+            tr("Now move the stick several times to the maximum in different direction and back to center.\n"
+               "This can take up to %1 seconds.")
+                .arg(CAL_TIMEOUT));
+        setWindowTitle(tr("Calibrating stick"));
+        m_ui->startBtn->setText(tr("Continue calibration"));
+        m_ui->startBtn->setEnabled(false);
+
+        m_ui->resetBtn->setEnabled(false);
+        m_ui->deviceComboBox->setEnabled(false);
+        disconnect(m_ui->startBtn, &QPushButton::clicked, this, nullptr);
+        connect(m_ui->startBtn, &QPushButton::clicked, this, &Calibration::startStickGainCalibration);
+        connect(m_stick, &JoyControlStick::moved, this, &Calibration::onStickOffsetData);
         update();
-        QMessageBox::information(this, tr("Save"), tr("Calibration values have been saved"));
     }
 }
 
 /**
- * @brief checks whether axes were moved at least 5 times in both ways. If not, it shows a message
- * @param counts of ax X moving values
- * @param counts of ax Y moving values
- * @return if counts of values for X and Y axes were greater than 4
+ * @brief Shows user instructions for stick gain calibration, initializes estimators
+ *  and connects stick data event handlers.
  */
-bool Calibration::enoughProb(int x_count, int y_count, QString character)
+void Calibration::startStickGainCalibration()
 {
-    bool enough = true;
+    if (m_stick == nullptr)
+        return;
 
-    if ((x_count < 5) || (y_count < 5))
-    {
-        if (character == QString("-"))
-        {
-            enough = false;
-            QMessageBox::information(this, tr("Dead zone calibration"),
-                                     tr("You have to move axes to the top-left corner at least five times."));
-        } else if (character == QString("+"))
-        {
-            enough = false;
-            QMessageBox::information(this, tr("Dead zone calibration"),
-                                     tr("You have to move axes to the bottom-right corner at least five times."));
-        }
-    }
+    m_min[0].reset();
+    m_min[1].reset();
+    m_max[0].reset();
+    m_max[1].reset();
+    m_filter[0].reset();
+    m_filter[1].reset();
 
-    return enough;
-}
-
-/**
- * @brief it's a slot of moving ax Y. Counts positive and negative values for later comparisions
- * @param place for sign "+" or "-". Depends on we want to find max value or min value for ax
- * @param list of moving ax values in positive and negative ways
- * @return min value if sign was "-" or max value if sign was "+"
- */
-int Calibration::chooseMinMax(QString min_max_sign, QList<int> ax_values)
-{
-    int min_max = 0;
-
-    foreach (int val, ax_values)
-    {
-        if (min_max_sign == QString("+"))
-        {
-            if (min_max < val)
-                min_max = val;
-        } else
-        {
-            if (min_max > val)
-                min_max = val;
-        }
-    }
-
-    return min_max;
-}
-
-/**
- * @brief it's a slot of moving ax X. Counts positive and negative values for later comparisions
- * @param value of moving ax
- * @return nothing
- */
-void Calibration::checkX(int value)
-{
-    if (value > 0)
-    {
-        if (x_es_val.count(QString("+")) <= 100)
-            x_es_val.insert(QString("+"), value);
-    } else if (value < 0)
-    {
-        if (x_es_val.count(QString("-")) <= 100)
-            x_es_val.insert(QString("-"), value);
-    }
-
-    axisBarX->setValue(value);
-    update();
-}
-
-/**
- * @brief it's a slot of moving ax Y. Counts positive and negative values for later comparisions
- * @param value of moving ax
- * @return nothing
- */
-void Calibration::checkY(int value)
-{
-    if (value > 0)
-    {
-        if (y_es_val.count(QString("+")) <= 100)
-            y_es_val.insert(QString("+"), value);
-
-    } else if (value < 0)
-    {
-        if (y_es_val.count(QString("-")) <= 100)
-            y_es_val.insert(QString("-"), value);
-    }
-
-    axisBarY->setValue(value);
-    update();
-}
-
-/**
- * @brief Refreshes list of sticks, which is below input devices list
- * @return nothing
- */
-void Calibration::updateAxesBox()
-{
-    ui->axesBox->clear();
-    QList<JoyControlStick *> sticksList = currentJoystick->getActiveSetJoystick()->getSticks().values();
-    QListIterator<JoyControlStick *> currStick(sticksList);
-
-    while (currStick.hasNext())
-    {
-        ui->axesBox->addItem(currStick.next()->getPartialName());
-    }
-
-    update();
-}
-
-/**
- * @brief Initializes widget for moving axes (animations) and changes storing data for variables
- * @return nothing
- */
-void Calibration::createAxesConnection()
-{
-    if (ui->saveBtn->isEnabled())
-    {
-        QMessageBox msgBox;
-        msgBox.setText(tr("Do you want to save calibration of current axis?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-
-        switch (msgBox.exec())
-        {
-        case QMessageBox::Yes:
-            saveSettings();
-            break;
-
-        case QMessageBox::No:
-            break;
-
-        default:
-            break;
-        }
-    }
-
-    while (!ui->progressBarsLayout->isEmpty())
-    {
-        QLayout *hb = ui->progressBarsLayout->takeAt(0)->layout();
-
-        while (!hb->isEmpty())
-        {
-            QWidget *w = hb->takeAt(0)->widget();
-            w->deleteLater();
-        }
-
-        hb->deleteLater();
-    }
-
+    m_ui->steps->setText(tr("Now move the stick in full circles for several times.\n"
+                            "This can take up to %1 seconds.")
+                             .arg(CAL_TIMEOUT));
+    m_ui->startBtn->setEnabled(false);
     update();
 
-    QPointer<JoyControlStick> controlstick =
-        currentJoystick->getActiveSetJoystick()->getJoyStick(ui->axesBox->currentIndex());
-    this->stick = controlstick.data();
-
-    if (calibrated)
-        ui->resetBtn->setEnabled(true);
-    else
-        ui->resetBtn->setEnabled(false);
-
-    controlstick.data()->getModifierButton()->establishPropertyUpdatedConnections();
-    helper.moveToThread(controlstick.data()->thread());
-    ui->stickStatusBoxWidget->setStick(controlstick.data());
-    ui->stickStatusBoxWidget->update();
-    setProgressBars(controlstick.data());
-
-    update();
-
-    if (controlstick.isNull())
-        controlstick.clear();
-}
-
-/**
- * @brief Creates progress bars for axes and creates connections
- * @param pointer to stick
- * @return nothing
- */
-void Calibration::setProgressBars(JoyControlStick *controlstick)
-{
-    joyAxisX = controlstick->getAxisX();
-    joyAxisY = controlstick->getAxisY();
-
-    if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
-    {
-        QHBoxLayout *hbox = new QHBoxLayout();
-        QHBoxLayout *hbox2 = new QHBoxLayout();
-
-        QLabel *axisLabel = new QLabel();
-        QLabel *axisLabel2 = new QLabel();
-
-        axisLabel->setText(tr("Axis %1").arg(joyAxisX->getRealJoyIndex()));
-        axisLabel2->setText(tr("Axis %1").arg(joyAxisY->getRealJoyIndex()));
-
-        axisBarX = new QProgressBar();
-        axisBarY = new QProgressBar();
-
-        axisBarX->setMinimum(GlobalVariables::JoyAxis::AXISMIN);
-        axisBarX->setMaximum(GlobalVariables::JoyAxis::AXISMAX);
-
-        axisBarX->setFormat("%v");
-        axisBarX->setValue(joyAxisX->getCurrentRawValue());
-
-        axisBarY->setMinimum(GlobalVariables::JoyAxis::AXISMIN);
-        axisBarY->setMaximum(GlobalVariables::JoyAxis::AXISMAX);
-        axisBarY->setFormat("%v");
-        axisBarY->setValue(joyAxisY->getCurrentRawValue());
-
-        hbox->addWidget(axisLabel);
-        hbox->addWidget(axisBarX);
-        hbox->addSpacing(10);
-        hbox2->addWidget(axisLabel2);
-        hbox2->addWidget(axisBarY);
-        hbox2->addSpacing(10);
-
-        ui->progressBarsLayout->addLayout(hbox);
-        ui->progressBarsLayout->addLayout(hbox2);
-
-        connect(joyAxisX, &JoyAxis::moved, this, &Calibration::checkX);
-        connect(joyAxisY, &JoyAxis::moved, this, &Calibration::checkY);
-    }
-
-    update();
-}
-
-/**
- * @brief Creates progress bars for axes and creates connections
- * @param device number
- * @param joystick number
- * @param stick number
- * @return nothing
- */
-void Calibration::setProgressBars(int setJoyNr, int stickNr)
-{
-    JoyControlStick *controlstick = currentJoystick->getActiveSetJoystick()->getJoyStick(stickNr);
-    // helper.moveToThread(controlstick->thread());
-
-    joyAxisX = controlstick->getAxisX();
-    joyAxisY = controlstick->getAxisY();
-
-    if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
-    {
-        QHBoxLayout *hbox = new QHBoxLayout();
-        QHBoxLayout *hbox2 = new QHBoxLayout();
-
-        QLabel *axisLabel = new QLabel();
-        QLabel *axisLabel2 = new QLabel();
-
-        axisLabel->setText(tr("Axis %1").arg(joyAxisX->getRealJoyIndex()));
-        axisLabel2->setText(tr("Axis %1").arg(joyAxisY->getRealJoyIndex()));
-
-        axisBarX = new QProgressBar();
-        axisBarY = new QProgressBar();
-
-        axisBarX->setMinimum(GlobalVariables::JoyAxis::AXISMIN);
-        axisBarX->setMaximum(GlobalVariables::JoyAxis::AXISMAX);
-
-        axisBarX->setFormat("%v");
-        axisBarX->setValue(joyAxisX->getCurrentRawValue());
-
-        axisBarY->setMinimum(GlobalVariables::JoyAxis::AXISMIN);
-        axisBarY->setMaximum(GlobalVariables::JoyAxis::AXISMAX);
-        axisBarY->setFormat("%v");
-        axisBarY->setValue(joyAxisY->getCurrentRawValue());
-
-        hbox->addWidget(axisLabel);
-        hbox->addWidget(axisBarX);
-        hbox->addSpacing(10);
-        hbox2->addWidget(axisLabel2);
-        hbox2->addWidget(axisBarY);
-        hbox2->addSpacing(10);
-
-        ui->progressBarsLayout->addLayout(hbox);
-        ui->progressBarsLayout->addLayout(hbox2);
-
-        connect(joyAxisX, &JoyAxis::moved, this, &Calibration::checkX);
-        connect(joyAxisY, &JoyAxis::moved, this, &Calibration::checkY);
-    }
-
-    update();
+    disconnect(m_ui->startBtn, &QPushButton::clicked, this, nullptr);
+    connect(m_ui->startBtn, &QPushButton::clicked, this, &Calibration::startStickOffsetCalibration);
+    connect(m_stick, &JoyControlStick::moved, this, &Calibration::onStickGainData);
+    m_end_time = QDateTime::currentDateTime().addSecs(CAL_TIMEOUT);
 }

--- a/src/gui/calibration.cpp
+++ b/src/gui/calibration.cpp
@@ -64,8 +64,6 @@ Calibration::Calibration(InputDevice *joystick, QWidget *parent)
 
     QPointer<JoyControlStick> controlstick = currentJoystick->getActiveSetJoystick()->getJoyStick(0);
     this->stick = controlstick.data();
-    calibrated = this->stick->wasCalibrated();
-    ui->Information->setText(stick->getCalibrationSummary());
 
     ui->resetBtn->setEnabled(calibrated);
     ui->saveBtn->setEnabled(false);
@@ -152,14 +150,6 @@ void Calibration::restoreCalValues()
     x_es_val.clear();
     y_es_val.clear();
 
-    joyAxisX->setAxisCenterCal(center_calibrated_x);
-    joyAxisY->setAxisCenterCal(center_calibrated_y);
-
-    joyAxisX->setAxisMinCal(GlobalVariables::JoyAxis::AXISMIN);
-    joyAxisY->setAxisMinCal(GlobalVariables::JoyAxis::AXISMIN);
-    joyAxisX->setAxisMaxCal(GlobalVariables::JoyAxis::AXISMAX);
-    joyAxisY->setAxisMaxCal(GlobalVariables::JoyAxis::AXISMAX);
-
     joyAxisX->setDeadZone(GlobalVariables::JoyAxis::AXISDEADZONE);
     joyAxisY->setDeadZone(GlobalVariables::JoyAxis::AXISDEADZONE);
 
@@ -169,8 +159,6 @@ void Calibration::restoreCalValues()
     stick->setDeadZone(GlobalVariables::JoyAxis::AXISDEADZONE);
     stick->setMaxZone(GlobalVariables::JoyAxis::AXISMAXZONE);
 
-    stick->setCalibrationFlag(false);
-    stick->setCalibrationSummary(QString());
     ui->Information->clear();
 
     calibrated = false;
@@ -234,7 +222,7 @@ void Calibration::startCalibration()
 {
     bool confirmed = true;
 
-    if (stick->wasCalibrated())
+    if (false)
     {
         QMessageBox msgBox;
         msgBox.setText(tr("Calibration was saved for the preset. Do you really want to reset settings?"));
@@ -286,7 +274,6 @@ void Calibration::startCalibration()
         x_es_val.clear();
         y_es_val.clear();
 
-        stick->setCalibrationFlag(false);
         calibrated = false;
 
         ui->steps->setText(tr("Place the joystick in the center position.\n\nIt's the part, where often you don't have to "
@@ -458,29 +445,6 @@ void Calibration::saveSettings()
 {
     if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
     {
-        joyAxisX->setAxisCenterCal(center_calibrated_x);
-        joyAxisY->setAxisCenterCal(center_calibrated_y);
-
-        joyAxisX->setDeadZone(deadzone_calibrated_x);
-        joyAxisY->setDeadZone(deadzone_calibrated_y);
-
-        stick->setDeadZone(deadzone_calibrated_x);
-
-        joyAxisX->setAxisMinCal(min_axis_val_x);
-        joyAxisY->setAxisMinCal(min_axis_val_y);
-
-        joyAxisX->setAxisMaxCal(max_axis_val_x);
-        joyAxisY->setAxisMaxCal(max_axis_val_y);
-
-        joyAxisX->setMaxZoneValue(max_axis_val_x);
-        joyAxisY->setMaxZoneValue(max_axis_val_y);
-
-        stick->setMaxZone(max_axis_val_x);
-        calibrated = true;
-
-        stick->setCalibrationFlag(true);
-        stick->setCalibrationSummary(this->text);
-
         ui->resetBtn->setEnabled(true);
         ui->saveBtn->setEnabled(false);
 
@@ -650,21 +614,6 @@ void Calibration::createAxesConnection()
         currentJoystick->getActiveSetJoystick()->getJoyStick(ui->axesBox->currentIndex());
     this->stick = controlstick.data();
 
-    center_calibrated_x = controlstick->getAxisX()->getAxisCenterCal();
-    center_calibrated_y = controlstick->getAxisY()->getAxisCenterCal();
-
-    deadzone_calibrated_x = controlstick->getAxisX()->getDeadZone();
-    deadzone_calibrated_y = controlstick->getAxisY()->getDeadZone();
-
-    min_axis_val_x = controlstick->getAxisX()->getAxisMinCal();
-    min_axis_val_y = controlstick->getAxisY()->getAxisMinCal();
-
-    max_axis_val_x = controlstick->getAxisX()->getAxisMaxCal();
-    max_axis_val_y = controlstick->getAxisY()->getAxisMaxCal();
-
-    calibrated = controlstick->wasCalibrated();
-    text = controlstick->getCalibrationSummary();
-
     if (calibrated)
         ui->resetBtn->setEnabled(true);
     else
@@ -691,9 +640,6 @@ void Calibration::setProgressBars(JoyControlStick *controlstick)
 {
     joyAxisX = controlstick->getAxisX();
     joyAxisY = controlstick->getAxisY();
-
-    calibrated = controlstick->wasCalibrated();
-    ui->Information->setText(controlstick->getCalibrationSummary());
 
     if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
     {
@@ -751,9 +697,6 @@ void Calibration::setProgressBars(int setJoyNr, int stickNr)
 
     joyAxisX = controlstick->getAxisX();
     joyAxisY = controlstick->getAxisY();
-
-    calibrated = controlstick->wasCalibrated();
-    ui->Information->setText(controlstick->getCalibrationSummary());
 
     if ((joyAxisX != nullptr) && (joyAxisY != nullptr))
     {

--- a/src/gui/calibration.ui
+++ b/src/gui/calibration.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>800</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -21,124 +21,58 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_6">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <item>
-              <widget class="JoyControlStickStatusBox" name="stickStatusBoxWidget" native="true">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>300</width>
-                 <height>300</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="sizeIncrement">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="baseSize">
-                <size>
-                 <width>200</width>
-                 <height>200</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QPushButton" name="startButton">
-           <property name="text">
-            <string>Start calibration</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="axesWidget" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>100</height>
-            </size>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <item>
-             <layout class="QVBoxLayout" name="progressBarsLayout"/>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="steps">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
+        <widget class="QStackedWidget" name="statusStack">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>300</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="sizeIncrement">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="baseSize">
+          <size>
+           <width>200</width>
+           <height>200</height>
+          </size>
+         </property>
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <widget class="JoyControlStickStatusBox" name="stickStatusBoxWidget"/>
+        </widget>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
          <item>
-          <spacer name="verticalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="label_16">
            <property name="text">
-            <string>Sticks:</string>
+            <string>Input to calibrate:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="axesBox"/>
+          <widget class="QComboBox" name="deviceComboBox"/>
          </item>
          <item>
           <spacer name="verticalSpacer_2">
@@ -153,14 +87,16 @@
            </property>
           </spacer>
          </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
          <item>
-          <widget class="QLabel" name="Information">
+          <widget class="QLabel" name="steps">
            <property name="text">
-            <string/>
+            <string>Steps</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -169,11 +105,146 @@
       </layout>
      </item>
      <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="3" column="0">
+        <widget class="QLabel" name="zAxisLabel">
+         <property name="text">
+          <string>Z</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QLabel" name="offsetZValue">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="xAxisLabel">
+         <property name="text">
+          <string>X</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="offsetYValue">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QLabel" name="gainXLabel">
+         <property name="text">
+          <string>gain</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLabel" name="offsetXValue">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="offsetXLabel">
+         <property name="text">
+          <string>offset</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="yAxisLabel">
+         <property name="text">
+          <string>Y</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="offsetZLabel">
+         <property name="text">
+          <string>offset</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="offsetYLabel">
+         <property name="text">
+          <string>offset</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QLabel" name="gainXValue">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QLabel" name="gainYLabel">
+         <property name="text">
+          <string>gain</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="QLabel" name="gainYValue">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QLabel" name="gainZLabel">
+         <property name="text">
+          <string>gain</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="4">
+        <widget class="QLabel" name="gainZValue">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QPushButton" name="resetBtn">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Reset settings</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="startBtn">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Start calibration</string>
          </property>
         </widget>
        </item>
@@ -191,16 +262,19 @@
         </spacer>
        </item>
        <item>
-        <widget class="QPushButton" name="cancelBtn">
+        <widget class="QPushButton" name="saveBtn">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
-          <string>Cancel</string>
+          <string>Save</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="saveBtn">
+        <widget class="QPushButton" name="cancelBtn">
          <property name="text">
-          <string>Save</string>
+          <string>Close</string>
          </property>
         </widget>
        </item>
@@ -215,7 +289,6 @@
    <class>JoyControlStickStatusBox</class>
    <extends>QWidget</extends>
    <header>joycontrolstickstatusbox.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/gui/joycontrolstickeditdialog.cpp
+++ b/src/gui/joycontrolstickeditdialog.cpp
@@ -45,6 +45,9 @@ JoyControlStickEditDialog::JoyControlStickEditDialog(JoyControlStick *stick, boo
     this->keypadUnlocked = keypadUnlocked;
     setAttribute(Qt::WA_DeleteOnClose);
 
+    auto min_width = ui->xCoordinateLabel->fontMetrics().boundingRect(QString("X.XXXXXXXXX")).width();
+    ui->xCoordinateLabel->setMinimumWidth(min_width);
+
     this->stick = stick;
     getHelperLocal().moveToThread(stick->thread());
 

--- a/src/gui/joycontrolstickeditdialog.ui
+++ b/src/gui/joycontrolstickeditdialog.ui
@@ -94,159 +94,136 @@
         </spacer>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <property name="spacing">
-          <number>10</number>
-         </property>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>X:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="xCoordinateLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Distance:</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <item>
-            <widget class="QLabel" name="label_6">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Y:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="yCoordinateLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Y:</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
-           <item>
-            <widget class="QLabel" name="label_8">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Distance:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="distanceLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="0" column="1">
+          <widget class="QLabel" name="xCoordinateLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_8">
-           <item>
-            <widget class="QLabel" name="bearingHeaderLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Bearing:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="diagonalLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>X:</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_9">
-           <item>
-            <widget class="QLabel" name="fromSafeZoneLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>% Safe Zone:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="fromSafeZoneValueLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="1" column="1">
+          <widget class="QLabel" name="yCoordinateLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="diagonalLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="distanceLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="bearingHeaderLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Bearing:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="fromSafeZoneLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>% Safe Zone:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="fromSafeZoneValueLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1611,3 +1611,23 @@ QList<int> &InputDevice::getAxesstatesLocal() { return axesstates; }
 QList<int> &InputDevice::getDpadstatesLocal() { return dpadstates; }
 
 SDL_Joystick *InputDevice::getJoyHandle() const { return m_joyhandle; }
+
+/**
+ * @brief Applies calibration to the specified stick in all sets
+ *  See JoyControlStick::setCalibration
+ * @param[in] index Stick index
+ * @param[in] offsetX Offset value for X axis
+ * @param[in] gainX Gain value for X axis
+ * @param[in] offsetY Offset value for Y axis
+ * @param[in] gainY Gain value for Y axis
+ */
+void InputDevice::applyStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY)
+{
+    for (auto iter = joystick_sets.begin(); iter != joystick_sets.end(); ++iter)
+    {
+        SetJoystick *set = iter.value();
+        JoyControlStick *stick = set->getSticks().value(index);
+        if (stick != nullptr)
+            stick->setCalibration(offsetX, gainX, offsetY, gainY);
+    }
+}

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -137,6 +137,8 @@ class InputDevice : public QObject
     QHash<int, SetJoystick *> &getJoystick_sets();
     SDL_Joystick *getJoyHandle() const;
 
+    void applyStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
+
   protected:
     void enableSetConnections(SetJoystick *setstick);
 

--- a/src/joyaxis.cpp
+++ b/src/joyaxis.cpp
@@ -41,9 +41,6 @@ JoyAxis::JoyAxis(int index, int originset, SetJoystick *parentSet, QObject *pare
     m_stick = nullptr;
     lastKnownThottledValue = 0;
     lastKnownRawValue = 0;
-    axis_max_cal = -1;
-    axis_min_cal = -1;
-    axis_center_cal = -1;
     currentRawValue = 0;
     m_originset = originset;
     m_parentSet = parentSet;
@@ -58,12 +55,14 @@ JoyAxis::~JoyAxis() { resetPrivateVars(); }
 
 void JoyAxis::queuePendingEvent(int value, bool ignoresets, bool updateLastValues)
 {
-    pendingEvent = false;
-    pendingValue = 0;
-    pendingIgnoreSets = false;
+    if (m_calibrated)
+        value = value * m_gain + m_offset;
 
     if (m_stick != nullptr)
     {
+        pendingEvent = false;
+        pendingValue = 0;
+        pendingIgnoreSets = false;
         stickPassEvent(value, ignoresets, updateLastValues);
     } else
     {
@@ -274,13 +273,13 @@ int JoyAxis::calculateThrottledValue(int value)
     case -1:
         // *log << ". It's a negative throttle.";
 
-        temp = (value + getAxisMinCal()) / 2;
+        temp = (value + GlobalVariables::JoyAxis::AXISMIN) / 2;
         break;
 
     case 1:
         // *log << ". It's a positive throttle.";
 
-        temp = (value + getAxisMaxCal()) / 2;
+        temp = (value + GlobalVariables::JoyAxis::AXISMAX) / 2;
         break;
 
     case 2:
@@ -347,9 +346,9 @@ void JoyAxis::setMaxZoneValue(int value)
 {
     value = abs(value);
 
-    if (value >= getAxisMaxCal())
+    if (value >= GlobalVariables::JoyAxis::AXISMAX)
     {
-        maxZoneValue = getAxisMaxCal();
+        maxZoneValue = GlobalVariables::JoyAxis::AXISMAX;
         emit propertyUpdated();
     } else
     {
@@ -423,6 +422,7 @@ void JoyAxis::resetPrivateVars()
     currentThrottledValue = calculateThrottledValue(currentRawValue);
     axisName.clear();
 
+    m_calibrated = false;
     pendingEvent = false;
     pendingValue = currentRawValue;
     pendingIgnoreSets = false;
@@ -444,7 +444,7 @@ void JoyAxis::adjustRange()
 {
     if (throttle == static_cast<int>(JoyAxis::NegativeThrottle))
     {
-        currentThrottledDeadValue = getAxisMaxCal();
+        currentThrottledDeadValue = GlobalVariables::JoyAxis::AXISMAX;
     } else if ((throttle == static_cast<int>(JoyAxis::NormalThrottle)) ||
                (throttle == static_cast<int>(JoyAxis::PositiveHalfThrottle)) ||
                (throttle == static_cast<int>(JoyAxis::NegativeHalfThrottle)))
@@ -452,7 +452,7 @@ void JoyAxis::adjustRange()
         currentThrottledDeadValue = 0;
     } else if (throttle == static_cast<int>(JoyAxis::PositiveThrottle))
     {
-        currentThrottledDeadValue = getAxisMinCal();
+        currentThrottledDeadValue = GlobalVariables::JoyAxis::AXISMIN;
     }
 
     currentThrottledValue = calculateThrottledValue(currentRawValue);
@@ -558,25 +558,7 @@ bool JoyAxis::isDefault()
  */
 void JoyAxis::setCurrentRawValue(int value)
 {
-    // QScopedPointer<LogHelper> log(new DEBUG());
-    if ((value >= getAxisMinCal()) && (value <= getAxisMaxCal()))
-    {
-        // *log << "Raw value is less than " << getAxisMaxCal() << " and greather than " << getAxisMinCal();
-
-        currentRawValue = value;
-    } else if (value > getAxisMaxCal())
-    {
-        // *log << "Raw value is greather than " << getAxisMaxCal();
-
-        currentRawValue = getAxisMaxCal();
-    } else if (value < getAxisMinCal())
-    {
-        // *log << "Raw value is less than " << getAxisMinCal();
-
-        currentRawValue = getAxisMinCal();
-    }
-
-    // *log << " (" << currentRawValue << ")";
+    currentRawValue = qBound(GlobalVariables::JoyAxis::AXISMIN, value, GlobalVariables::JoyAxis::AXISMAX);
 }
 
 void JoyAxis::setButtonsMouseMode(JoyButton::JoyMouseMovementMode mode)
@@ -862,10 +844,10 @@ int JoyAxis::getProperReleaseValue()
         value = 0;
     } else if (throttle == static_cast<int>(NegativeThrottle))
     {
-        value = getAxisMaxCal();
+        value = GlobalVariables::JoyAxis::AXISMAX;
     } else if (throttle == static_cast<int>(PositiveThrottle))
     {
-        value = getAxisMinCal();
+        value = GlobalVariables::JoyAxis::AXISMIN;
     } else if (throttle == static_cast<int>(PositiveHalfThrottle))
     {
         value = 0;
@@ -910,14 +892,35 @@ void JoyAxis::eventReset()
     paxisbutton->eventReset();
 }
 
-void JoyAxis::setAxisMinCal(int value) { axis_min_cal = value; }
+/**
+ * @brief Check if the axis is calibrated
+ * @returns True if the axis is calibrated, false otherwise.
+ */
+bool JoyAxis::isCalibrated() const { return m_calibrated; }
 
-int JoyAxis::getAxisMinCal() { return ((axis_min_cal != -1) ? axis_min_cal : GlobalVariables::JoyAxis::AXISMIN); }
+/**
+ * @brief Resets the axis calibration back to uncalibrated state.
+ */
+void JoyAxis::resetCalibration() { m_calibrated = false; }
 
-void JoyAxis::setAxisMaxCal(int value) { axis_max_cal = value; }
+/**
+ * @brief Reads the axis calibration values
+ * @param[out] offset Offset value "a"
+ * @param[out] gain Gain value "b"
+ */
+void JoyAxis::getCalibration(double *offset, double *gain) const
+{
+    *offset = m_offset;
+    *gain = m_gain;
+}
 
-int JoyAxis::getAxisMaxCal() { return ((axis_max_cal != -1) ? axis_max_cal : GlobalVariables::JoyAxis::AXISMAX); }
-
-void JoyAxis::setAxisCenterCal(int value) { axis_center_cal = value; }
-
-int JoyAxis::getAxisCenterCal() { return ((axis_center_cal != -1) ? axis_center_cal : 0); }
+/**
+ * @brief Sets the axis calibration values and sets the calibration flag.
+ *  Calibrated value is calculated by the formula "a+b*x".
+ */
+void JoyAxis::setCalibration(double offset, double gain)
+{
+    m_calibrated = true;
+    m_offset = offset;
+    m_gain = gain;
+}

--- a/src/joyaxis.h
+++ b/src/joyaxis.h
@@ -112,14 +112,10 @@ class JoyAxis : public QObject
 
     double getButtonsEasingDuration();
 
-    void setAxisMinCal(int value);
-    int getAxisMinCal();
-
-    void setAxisMaxCal(int value);
-    int getAxisMaxCal();
-
-    void setAxisCenterCal(int value);
-    int getAxisCenterCal();
+    bool isCalibrated() const;
+    void resetCalibration();
+    void getCalibration(double *offset, double *gain) const;
+    void setCalibration(double offset, double gain);
 
     virtual QString getAxisName();
     virtual int getDefaultDeadZone();
@@ -173,9 +169,6 @@ class JoyAxis : public QObject
     int currentThrottledValue;
     int currentThrottledDeadValue;
     int m_index;
-    int axis_center_cal;
-    int axis_min_cal;
-    int axis_max_cal;
     int lastKnownThottledValue;
     int lastKnownRawValue;
     int pendingValue;
@@ -219,6 +212,10 @@ class JoyAxis : public QObject
     JoyControlStick *m_stick;
 
     SetJoystick *m_parentSet;
+
+    bool m_calibrated;
+    double m_offset;
+    double m_gain;
 
     void resetPrivateVars();
 };

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -45,7 +45,6 @@ JoyControlStick::JoyControlStick(JoyAxis *axis1, JoyAxis *axis2, int index, int 
     this->axisY = axis2;
     this->axisY->setControlStick(this);
 
-    this->calibrated = false;
     this->index = index;
     this->originset = originset;
     this->modifierButton = nullptr;
@@ -850,10 +849,7 @@ void JoyControlStick::reset()
 
 void JoyControlStick::setDeadZone(int value)
 {
-    value = abs(value);
-
-    if (value > getAxisX()->getAxisMaxCal())
-        value = getAxisX()->getAxisMaxCal();
+    value = std::min(abs(value), GlobalVariables::JoyAxis::AXISMAX);
 
     if ((value != deadZone) && (value <= maxZone))
     {
@@ -865,10 +861,7 @@ void JoyControlStick::setDeadZone(int value)
 
 void JoyControlStick::setMaxZone(int value)
 {
-    value = abs(value);
-
-    if (value >= getAxisX()->getAxisMaxCal())
-        value = getAxisX()->getAxisMaxCal();
+    value = std::min(abs(value), GlobalVariables::JoyAxis::AXISMAX);
 
     if ((value != maxZone) && (value > deadZone))
     {
@@ -878,13 +871,47 @@ void JoyControlStick::setMaxZone(int value)
     }
 }
 
-bool JoyControlStick::wasCalibrated() { return calibrated; }
+/**
+ * @brief Check if the stick is calibrated
+ * @returns True if both axes of the stick are calibrated, false otherwise.
+ */
+bool JoyControlStick::isCalibrated() const { return axisX->isCalibrated() && axisY->isCalibrated(); }
 
-void JoyControlStick::setCalibrationFlag(bool flag) { calibrated = flag; }
+/**
+ * @brief Resets the calibration of both stick axes back to uncalibrated state.
+ */
+void JoyControlStick::resetCalibration()
+{
+    axisX->resetCalibration();
+    axisY->resetCalibration();
+}
 
-QString JoyControlStick::getCalibrationSummary() { return calibrationSummary; }
+/**
+ * @brief Reads the calibration values of both stick axes
+ * @param[out] offsetX Offset value "a" for X axis
+ * @param[out] gainX Gain value "b" for X axis
+ * @param[out] offsetY Offset value "a" for Y axis
+ * @param[out] gainY Gain value "b" for Y axis
+ */
+void JoyControlStick::getCalibration(double *offsetX, double *gainX, double *offsetY, double *gainY) const
+{
+    axisX->getCalibration(offsetX, gainX);
+    axisY->getCalibration(offsetY, gainY);
+}
 
-void JoyControlStick::setCalibrationSummary(QString text) { calibrationSummary = text; }
+/**
+ * @brief Sets the axis calibration values and sets the calibration flag.
+ *  Calibrated value is calculated by the formula "a+b*x".
+ * @param[in] offsetX Offset value "a" for X axis
+ * @param[in] gainX Gain value "b" for X axis
+ * @param[in] offsetY Offset value "a" for Y axis
+ * @param[in] gainY Gain value "b" for Y axis
+ */
+void JoyControlStick::setCalibration(double offsetX, double gainX, double offsetY, double gainY)
+{
+    axisX->setCalibration(offsetX, gainX);
+    axisY->setCalibration(offsetY, gainY);
+}
 
 /**
  * @brief Set the diagonal range value for a stick.
@@ -928,15 +955,6 @@ void JoyControlStick::readConfig(QXmlStreamReader *xml)
                 QString temptext = xml->readElementText();
                 int tempchoice = temptext.toInt();
                 this->setMaxZone(tempchoice);
-            } else if ((xml->name() == "calibrated") && xml->isStartElement())
-            {
-                QString temptext = xml->readElementText();
-                bool tempchoice = (temptext == "true") ? true : false;
-                this->setCalibrationFlag(tempchoice);
-            } else if ((xml->name() == "summary") && xml->isStartElement())
-            {
-                QString temptext = xml->readElementText();
-                this->setCalibrationSummary(temptext);
             } else if ((xml->name() == "diagonalRange") && xml->isStartElement())
             {
                 QString temptext = xml->readElementText();
@@ -1011,9 +1029,6 @@ void JoyControlStick::writeConfig(QXmlStreamWriter *xml)
 
         if (maxZone != GlobalVariables::JoyControlStick::DEFAULTMAXZONE)
             xml->writeTextElement("maxZone", QString::number(maxZone));
-
-        xml->writeTextElement("calibrated", (calibrated ? "true" : "false"));
-        xml->writeTextElement("summary", (getCalibrationSummary().isEmpty() ? "" : calibrationSummary));
 
         if ((currentMode == StandardMode || currentMode == EightWayMode) &&
             (diagonalRange != GlobalVariables::JoyControlStick::DEFAULTDIAGONALRANGE))

--- a/src/joycontrolstick.h
+++ b/src/joycontrolstick.h
@@ -56,16 +56,16 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     void queueJoyEvent(bool ignoresets); // JoyControlStickEvent class
     void activatePendingEvent();         // JoyControlStickEvent class
     void clearPendingEvent();            // JoyControlStickEvent class
-    void setCalibrationFlag(bool flag);
-    void setCalibrationSummary(QString text);
-
-    QString getCalibrationSummary();
 
     bool inDeadZone();
     bool hasSlotsAssigned();
     bool isRelativeSpring();
     bool hasPendingEvent(); // JoyControlStickEvent class
-    bool wasCalibrated();
+
+    bool isCalibrated() const;
+    void resetCalibration();
+    void getCalibration(double *offsetX, double *gainX, double *offsetY, double *gainY) const;
+    void setCalibration(double offsetX, double gainX, double offsetY, double gainY);
 
     int getDeadZone();
     int getDiagonalRange();
@@ -278,9 +278,6 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     bool isActive;
     bool safezone;
     bool pendingStickEvent;
-    bool calibrated;
-
-    QString calibrationSummary;
 
     QPointer<JoyAxis> axisX;
     QPointer<JoyAxis> axisY;

--- a/src/joycontrolstickstatusbox.cpp
+++ b/src/joycontrolstickstatusbox.cpp
@@ -34,45 +34,41 @@
 
 JoyControlStickStatusBox::JoyControlStickStatusBox(QWidget *parent)
     : QWidget(parent)
+    , m_stick(nullptr)
 {
-    this->stick = nullptr;
 }
 
 JoyControlStickStatusBox::JoyControlStickStatusBox(JoyControlStick *stick, QWidget *parent)
     : QWidget(parent)
+    , m_stick(nullptr)
 {
-    this->stick = stick;
-
-    connect(stick, SIGNAL(deadZoneChanged(int)), this, SLOT(update()));
-    connect(stick, SIGNAL(moved(int, int)), this, SLOT(update()));
-    connect(stick, SIGNAL(diagonalRangeChanged(int)), this, SLOT(update()));
-    connect(stick, SIGNAL(maxZoneChanged(int)), this, SLOT(update()));
-    connect(stick, SIGNAL(joyModeChanged()), this, SLOT(update()));
-    connect(stick, SIGNAL(circleAdjustChange(double)), this, SLOT(update()));
+    setStick(stick);
 }
 
 void JoyControlStickStatusBox::setStick(JoyControlStick *stick)
 {
-    if (stick != nullptr)
+    if (m_stick != nullptr)
     {
         disconnect(stick, SIGNAL(deadZoneChanged(int)), this, nullptr);
         disconnect(stick, SIGNAL(moved(int, int)), this, nullptr);
         disconnect(stick, SIGNAL(diagonalRangeChanged(int)), this, nullptr);
         disconnect(stick, SIGNAL(maxZoneChanged(int)), this, nullptr);
         disconnect(stick, SIGNAL(joyModeChanged()), this, nullptr);
+        disconnect(stick, SIGNAL(circleAdjustChange(double)), this, nullptr);
     }
 
-    this->stick = stick;
+    m_stick = stick;
     connect(stick, SIGNAL(deadZoneChanged(int)), this, SLOT(update()));
     connect(stick, SIGNAL(moved(int, int)), this, SLOT(update()));
     connect(stick, SIGNAL(diagonalRangeChanged(int)), this, SLOT(update()));
     connect(stick, SIGNAL(maxZoneChanged(int)), this, SLOT(update()));
     connect(stick, SIGNAL(joyModeChanged()), this, SLOT(update()));
+    connect(stick, SIGNAL(circleAdjustChange(double)), this, SLOT(update()));
 
     update();
 }
 
-JoyControlStick *JoyControlStickStatusBox::getStick() const { return stick; }
+JoyControlStick *JoyControlStickStatusBox::getStick() const { return m_stick; }
 
 int JoyControlStickStatusBox::heightForWidth(int width) const { return width; }
 
@@ -84,13 +80,14 @@ void JoyControlStickStatusBox::paintEvent(QPaintEvent *event)
 
     PadderCommon::inputDaemonMutex.lock();
 
-    if ((stick->getJoyMode() == JoyControlStick::StandardMode) || (stick->getJoyMode() == JoyControlStick::EightWayMode))
+    if (m_stick == nullptr || m_stick->getJoyMode() == JoyControlStick::StandardMode ||
+        m_stick->getJoyMode() == JoyControlStick::EightWayMode)
     {
         drawEightWayBox();
-    } else if (stick->getJoyMode() == JoyControlStick::FourWayCardinal)
+    } else if (m_stick->getJoyMode() == JoyControlStick::FourWayCardinal)
     {
         drawFourWayCardinalBox();
-    } else if (stick->getJoyMode() == JoyControlStick::FourWayDiagonal)
+    } else if (m_stick->getJoyMode() == JoyControlStick::FourWayDiagonal)
     {
         drawFourWayDiagonalBox();
     }
@@ -123,32 +120,37 @@ void JoyControlStickStatusBox::drawEightWayBox()
     painter.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
 
     // Draw diagonal zones
-    QList<double> anglesList = stick->getDiagonalZoneAngles();
+    if (m_stick != nullptr)
+    {
+        QList<double> anglesList = m_stick->getDiagonalZoneAngles();
+        int diagonalRange = m_stick->getDiagonalRange();
 
-    penny.setWidth(0);
-    penny.setColor(Qt::black);
-    painter.setPen(penny);
-    painter.setBrush(QBrush(Qt::green));
+        penny.setWidth(0);
+        penny.setColor(Qt::black);
+        painter.setPen(penny);
+        painter.setBrush(QBrush(Qt::green));
 
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
-                    static_cast<int>(anglesList.value(2)) * 16, stick->getDiagonalRange() * 16);
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
-                    static_cast<int>(anglesList.value(4)) * 16, stick->getDiagonalRange() * 16);
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
-                    static_cast<int>(anglesList.value(6)) * 16, stick->getDiagonalRange() * 16);
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
-                    static_cast<int>(anglesList.value(8)) * 16, stick->getDiagonalRange() * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        static_cast<int>(anglesList.value(2)) * 16, diagonalRange * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        static_cast<int>(anglesList.value(4)) * 16, diagonalRange * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        static_cast<int>(anglesList.value(6)) * 16, diagonalRange * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        static_cast<int>(anglesList.value(8)) * 16, diagonalRange * 16);
+    }
 
     // Draw deadzone circle
     penny.setWidth(0);
     penny.setColor(Qt::blue);
     painter.setPen(penny);
     painter.setBrush(QBrush(Qt::red));
-    painter.drawEllipse(-stick->getDeadZone(), -stick->getDeadZone(), stick->getDeadZone() * 2, stick->getDeadZone() * 2);
+    int deadZone = m_stick != nullptr ? m_stick->getDeadZone() : 0;
+    painter.drawEllipse(-deadZone, -deadZone, deadZone * 2, deadZone * 2);
 
     painter.restore();
 
@@ -174,43 +176,38 @@ void JoyControlStickStatusBox::drawEightWayBox()
     penny.setColor(Qt::black);
     painter.setPen(penny);
 
-    // Draw raw crosshair
-    int linexstart = stick->getXCoordinate() - 1000;
-    int lineystart = stick->getYCoordinate() - 1000;
-
-    if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+    if (m_stick != nullptr)
     {
-        linexstart = GlobalVariables::JoyAxis::AXISMIN;
+        // Draw raw crosshair
+        int linexstart = m_stick->getXCoordinate() - 1000;
+        int lineystart = m_stick->getYCoordinate() - 1000;
+
+        if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+            linexstart = GlobalVariables::JoyAxis::AXISMIN;
+
+        if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
+            lineystart = GlobalVariables::JoyAxis::AXISMIN;
+
+        painter.drawRect(linexstart, lineystart, 2000, 2000);
+
+        painter.setBrush(QBrush(Qt::darkBlue));
+        penny.setColor(Qt::darkBlue);
+        painter.setPen(penny);
+
+        // Draw adjusted crosshair
+        linexstart = m_stick->getCircleXCoordinate() - 1000;
+        lineystart = m_stick->getCircleYCoordinate() - 1000;
+        if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+            linexstart = GlobalVariables::JoyAxis::AXISMIN;
+
+        if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
+            lineystart = GlobalVariables::JoyAxis::AXISMIN;
+
+        painter.drawRect(linexstart, lineystart, 2000, 2000);
     }
-
-    if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        lineystart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    painter.drawRect(linexstart, lineystart, 2000, 2000);
-
-    painter.setBrush(QBrush(Qt::darkBlue));
-    penny.setColor(Qt::darkBlue);
-    painter.setPen(penny);
-
-    // Draw adjusted crosshair
-    linexstart = stick->getCircleXCoordinate() - 1000;
-    lineystart = stick->getCircleYCoordinate() - 1000;
-    if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        linexstart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        lineystart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    painter.drawRect(linexstart, lineystart, 2000, 2000);
-    painter.restore();
 
     // Reset pen
+    painter.restore();
     penny.setColor(Qt::black);
     painter.setPen(penny);
 
@@ -226,7 +223,7 @@ void JoyControlStickStatusBox::drawEightWayBox()
     paint.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
 
     // Draw max zone and initial inner clear circle
-    int maxzone = stick->getMaxZone();
+    int maxzone = m_stick != nullptr ? m_stick->getMaxZone() : GlobalVariables::JoyControlStick::DEFAULTMAXZONE;
     int diffmaxzone = GlobalVariables::JoyAxis::AXISMAX - maxzone;
     paint.setOpacity(0.5);
     paint.setBrush(Qt::darkGreen);
@@ -273,28 +270,32 @@ void JoyControlStickStatusBox::drawFourWayCardinalBox()
     painter.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
 
     // Draw diagonal zones
-    QList<int> anglesList = stick->getFourWayCardinalZoneAngles();
-    penny.setWidth(0);
-    penny.setColor(Qt::black);
-    painter.setPen(penny);
-    painter.setOpacity(0.25);
-    painter.setBrush(QBrush(Qt::black));
+    if (m_stick != nullptr)
+    {
+        QList<int> anglesList = m_stick->getFourWayCardinalZoneAngles();
+        penny.setWidth(0);
+        penny.setColor(Qt::black);
+        painter.setPen(penny);
+        painter.setOpacity(0.25);
+        painter.setBrush(QBrush(Qt::black));
 
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2, anglesList.value(1) * 16,
-                    90 * 16);
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2, anglesList.value(3) * 16,
-                    90 * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        anglesList.value(1) * 16, 90 * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        anglesList.value(3) * 16, 90 * 16);
 
-    painter.setOpacity(1.0);
+        painter.setOpacity(1.0);
+    }
 
     // Draw deadzone circle
     penny.setWidth(0);
     penny.setColor(Qt::blue);
     painter.setPen(penny);
     painter.setBrush(QBrush(Qt::red));
-    painter.drawEllipse(-stick->getDeadZone(), -stick->getDeadZone(), stick->getDeadZone() * 2, stick->getDeadZone() * 2);
+    int deadZone = m_stick != nullptr ? m_stick->getDeadZone() : 0;
+    painter.drawEllipse(-deadZone, -deadZone, deadZone * 2, deadZone * 2);
 
     painter.restore();
 
@@ -321,43 +322,38 @@ void JoyControlStickStatusBox::drawFourWayCardinalBox()
     penny.setColor(Qt::black);
     painter.setPen(penny);
 
-    // Draw raw crosshair
-    int linexstart = stick->getXCoordinate() - 1000;
-    int lineystart = stick->getYCoordinate() - 1000;
-
-    if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+    if (m_stick != nullptr)
     {
-        linexstart = GlobalVariables::JoyAxis::AXISMIN;
+        // Draw raw crosshair
+        int linexstart = m_stick->getXCoordinate() - 1000;
+        int lineystart = m_stick->getYCoordinate() - 1000;
+
+        if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+            linexstart = GlobalVariables::JoyAxis::AXISMIN;
+
+        if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
+            lineystart = GlobalVariables::JoyAxis::AXISMIN;
+
+        painter.drawRect(linexstart, lineystart, 2000, 2000);
+
+        painter.setBrush(QBrush(Qt::darkBlue));
+        penny.setColor(Qt::darkBlue);
+        painter.setPen(penny);
+
+        // Draw adjusted crosshair
+        linexstart = m_stick->getCircleXCoordinate() - 1000;
+        lineystart = m_stick->getCircleYCoordinate() - 1000;
+        if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+            linexstart = GlobalVariables::JoyAxis::AXISMIN;
+
+        if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
+            lineystart = GlobalVariables::JoyAxis::AXISMIN;
+
+        painter.drawRect(linexstart, lineystart, 2000, 2000);
     }
-
-    if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        lineystart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    painter.drawRect(linexstart, lineystart, 2000, 2000);
-
-    painter.setBrush(QBrush(Qt::darkBlue));
-    penny.setColor(Qt::darkBlue);
-    painter.setPen(penny);
-
-    // Draw adjusted crosshair
-    linexstart = stick->getCircleXCoordinate() - 1000;
-    lineystart = stick->getCircleYCoordinate() - 1000;
-    if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        linexstart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        lineystart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    painter.drawRect(linexstart, lineystart, 2000, 2000);
-    painter.restore();
 
     // Reset pen
+    painter.restore();
     penny.setColor(Qt::black);
     painter.setPen(penny);
 
@@ -373,7 +369,7 @@ void JoyControlStickStatusBox::drawFourWayCardinalBox()
     paint.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
 
     // Draw max zone and initial inner clear circle
-    int maxzone = stick->getMaxZone();
+    int maxzone = m_stick != nullptr ? m_stick->getMaxZone() : GlobalVariables::JoyControlStick::DEFAULTMAXZONE;
     int diffmaxzone = GlobalVariables::JoyAxis::AXISMAX - maxzone;
     paint.setOpacity(0.5);
     paint.setBrush(Qt::darkGreen);
@@ -420,28 +416,32 @@ void JoyControlStickStatusBox::drawFourWayDiagonalBox()
     painter.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
 
     // Draw diagonal zones
-    QList<int> anglesList = stick->getFourWayDiagonalZoneAngles();
-    penny.setWidth(0);
-    penny.setColor(Qt::black);
-    painter.setPen(penny);
-    painter.setBrush(QBrush(Qt::black));
-    painter.setOpacity(0.25);
+    if (m_stick != nullptr)
+    {
+        QList<int> anglesList = m_stick->getFourWayDiagonalZoneAngles();
+        penny.setWidth(0);
+        penny.setColor(Qt::black);
+        painter.setPen(penny);
+        painter.setBrush(QBrush(Qt::black));
+        painter.setOpacity(0.25);
 
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2, anglesList.value(1) * 16,
-                    90 * 16);
-    painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
-                    GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2, anglesList.value(3) * 16,
-                    90 * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        anglesList.value(1) * 16, 90 * 16);
+        painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
+                        anglesList.value(3) * 16, 90 * 16);
 
-    painter.setOpacity(1.0);
+        painter.setOpacity(1.0);
+    }
 
     // Draw deadzone circle
     penny.setWidth(0);
     penny.setColor(Qt::blue);
     painter.setPen(penny);
     painter.setBrush(QBrush(Qt::red));
-    painter.drawEllipse(-stick->getDeadZone(), -stick->getDeadZone(), stick->getDeadZone() * 2, stick->getDeadZone() * 2);
+    int deadZone = m_stick != nullptr ? m_stick->getDeadZone() : 0;
+    painter.drawEllipse(-deadZone, -deadZone, deadZone * 2, deadZone * 2);
 
     painter.restore();
 
@@ -469,42 +469,37 @@ void JoyControlStickStatusBox::drawFourWayDiagonalBox()
     painter.setPen(penny);
 
     // Draw raw crosshair
-    int linexstart = stick->getXCoordinate() - 1000;
-    int lineystart = stick->getYCoordinate() - 1000;
-
-    if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+    if (m_stick != nullptr)
     {
-        linexstart = GlobalVariables::JoyAxis::AXISMIN;
+        int linexstart = m_stick->getXCoordinate() - 1000;
+        int lineystart = m_stick->getYCoordinate() - 1000;
+
+        if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+            linexstart = GlobalVariables::JoyAxis::AXISMIN;
+
+        if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
+            lineystart = GlobalVariables::JoyAxis::AXISMIN;
+
+        painter.drawRect(linexstart, lineystart, 2000, 2000);
+
+        painter.setBrush(QBrush(Qt::darkBlue));
+        penny.setColor(Qt::darkBlue);
+        painter.setPen(penny);
+
+        // Draw adjusted crosshair
+        linexstart = m_stick->getCircleXCoordinate() - 1000;
+        lineystart = m_stick->getCircleYCoordinate() - 1000;
+        if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
+            linexstart = GlobalVariables::JoyAxis::AXISMIN;
+
+        if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
+            lineystart = GlobalVariables::JoyAxis::AXISMIN;
+
+        painter.drawRect(linexstart, lineystart, 2000, 2000);
     }
-
-    if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        lineystart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    painter.drawRect(linexstart, lineystart, 2000, 2000);
-
-    painter.setBrush(QBrush(Qt::darkBlue));
-    penny.setColor(Qt::darkBlue);
-    painter.setPen(penny);
-
-    // Draw adjusted crosshair
-    linexstart = stick->getCircleXCoordinate() - 1000;
-    lineystart = stick->getCircleYCoordinate() - 1000;
-    if (linexstart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        linexstart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    if (lineystart < GlobalVariables::JoyAxis::AXISMIN)
-    {
-        lineystart = GlobalVariables::JoyAxis::AXISMIN;
-    }
-
-    painter.drawRect(linexstart, lineystart, 2000, 2000);
-    painter.restore();
 
     // Reset pen
+    painter.restore();
     penny.setColor(Qt::black);
     painter.setPen(penny);
 
@@ -520,7 +515,7 @@ void JoyControlStickStatusBox::drawFourWayDiagonalBox()
     paint.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
 
     // Draw max zone and initial inner clear circle
-    int maxzone = stick->getMaxZone();
+    int maxzone = m_stick != nullptr ? m_stick->getMaxZone() : GlobalVariables::JoyControlStick::DEFAULTMAXZONE;
     int diffmaxzone = GlobalVariables::JoyAxis::AXISMAX - maxzone;
     paint.setOpacity(0.5);
     paint.setBrush(Qt::darkGreen);

--- a/src/joycontrolstickstatusbox.h
+++ b/src/joycontrolstickstatusbox.h
@@ -47,7 +47,7 @@ class JoyControlStickStatusBox : public QWidget
     void drawFourWayDiagonalBox();
 
   private:
-    JoyControlStick *stick;
+    JoyControlStick *m_stick;
 };
 
 #endif // JOYCONTROLSTICKSTATUSBOX_H

--- a/src/pt1filter.cpp
+++ b/src/pt1filter.cpp
@@ -1,0 +1,45 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pt1filter.h"
+#include <Qt>
+
+const double PT1Filter::FALLBACK_RATE = 200;
+
+PT1Filter::PT1Filter(double tau, double rate)
+{
+    double period = qFuzzyIsNull(rate) ? 1 / FALLBACK_RATE : 1 / rate;
+    // Since it is a fixed rate filter, precalculte delta_t/tau
+    // to save one division during sample processing.
+    m_dt_tau = period / tau;
+    reset();
+}
+
+/**
+ * @brief Processes a new sample.
+ * @returns New filter output value.
+ */
+double PT1Filter::process(double value)
+{
+    m_value = m_value + m_dt_tau * (value - m_value);
+    return m_value;
+};
+
+/**
+ * @brief Resets the filter state to default.
+ */
+void PT1Filter::reset() { m_value = 0; }

--- a/src/pt1filter.h
+++ b/src/pt1filter.h
@@ -1,0 +1,43 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/**
+ * @brief Implementation of a first order lag or PT1 filter.
+ *  Can be used for example to smooth noisy values a bit or detect envelopes.
+ * @see https://en.wikipedia.org/wiki/Low-pass_filter
+ */
+class PT1Filter
+{
+  public:
+    PT1Filter(double tau = 1, double rate = 1);
+
+    double process(double value);
+    /**
+     * @brief Get the current filter output value.
+     * @returns Current filter output value.
+     */
+    inline double getValue() const { return m_value; }
+    void reset();
+
+    static const double FALLBACK_RATE;
+
+  private:
+    double m_dt_tau;
+    double m_value;
+};

--- a/src/statisticsestimator.cpp
+++ b/src/statisticsestimator.cpp
@@ -1,0 +1,61 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "statisticsestimator.h"
+
+StatisticsEstimator::StatisticsEstimator() { reset(); }
+
+/**
+ * @brief Resets the StatisticsEstimator so that it is ready to process a new data stream.
+ */
+void StatisticsEstimator::reset()
+{
+    m_mean = 0;
+    m_var = 0;
+    m_count = 0;
+}
+
+/**
+ * @brief Processes a new sample of the current data stream and updates internal
+ *  intermediate values.
+ */
+void StatisticsEstimator::process(double x)
+{
+    ++m_count;
+    double dx = x - m_mean;
+    m_mean += dx / m_count;
+    double dx2 = x - m_mean;
+    m_var += dx * dx2;
+}
+
+/**
+ * @brief Calculates the sample variance of the processed data stream from
+ *  internal intermediate values.
+ * @returns Sample variance
+ */
+double StatisticsEstimator::calculateVariance() const { return m_var / (m_count - 1); }
+
+/**
+ * @brief Calculates the squared relative three sigma error range, i.e. the squared
+ *  estimation accuracy in percent,  of the processed data stream from internal
+ *  intermediate values. Use the squared value to avoid expensive root calculation.
+ * @returns Squared relative error range.
+ */
+double StatisticsEstimator::calculateRelativeErrorSq() const
+{
+    return 9 * calculateVariance() / (m_count * m_mean * m_mean);
+}

--- a/src/statisticsestimator.h
+++ b/src/statisticsestimator.h
@@ -1,0 +1,50 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <cstddef>
+
+/**
+ * @brief Estimates mean of a data stream using Welford's algorithm and
+ *  calculates statistic properties.
+ */
+class StatisticsEstimator
+{
+  public:
+    StatisticsEstimator();
+
+    void reset();
+    void process(double x);
+
+    /**
+     * @brief Gets the amount of processed samples.
+     * @returns Processed sample count.
+     */
+    inline size_t getCount() const { return m_count; }
+    /**
+     * @brief Gets the mean of processed samples.
+     * @returns Mean of processed samples.
+     */
+    inline double getMean() const { return m_mean; }
+    double calculateVariance() const;
+    double calculateRelativeErrorSq() const;
+
+  private:
+    double m_mean;
+    double m_var;
+    size_t m_count;
+};

--- a/src/xml/joyaxisxml.cpp
+++ b/src/xml/joyaxisxml.cpp
@@ -81,9 +81,6 @@ void JoyAxisXml::writeConfig(QXmlStreamWriter *xml)
             xml->writeTextElement("maxZone", QString::number(m_joyAxis->getMaxZoneValue()));
     }
 
-    xml->writeTextElement("center_value", QString::number(m_joyAxis->getAxisCenterCal()));
-    xml->writeTextElement("min_value", QString::number(m_joyAxis->getAxisMinCal()));
-    xml->writeTextElement("max_value", QString::number(m_joyAxis->getAxisMaxCal()));
     xml->writeStartElement("throttle");
 
     switch (m_joyAxis->getThrottle())
@@ -142,33 +139,6 @@ bool JoyAxisXml::readMainConfig(QXmlStreamReader *xml)
         qDebug() << "From xml config max zone is: " << tempchoice;
 
         m_joyAxis->setMaxZoneValue(tempchoice);
-    } else if ((xml->name() == "center_value") && xml->isStartElement())
-    {
-        found = true;
-        QString temptext = xml->readElementText();
-        int tempchoice = temptext.toInt();
-
-        qDebug() << "From xml config center value is: " << tempchoice;
-
-        m_joyAxis->setAxisCenterCal(tempchoice);
-    } else if ((xml->name() == "min_value") && xml->isStartElement())
-    {
-        found = true;
-        QString temptext = xml->readElementText();
-        int tempchoice = temptext.toInt();
-
-        qDebug() << "From xml config min value is: " << tempchoice;
-
-        m_joyAxis->setAxisMinCal(tempchoice);
-    } else if ((xml->name() == "max_value") && xml->isStartElement())
-    {
-        found = true;
-        QString temptext = xml->readElementText();
-        int tempchoice = temptext.toInt();
-
-        qDebug() << "From xml config max value is: " << tempchoice;
-
-        m_joyAxis->setAxisMaxCal(tempchoice);
     } else if ((xml->name() == "throttle") && xml->isStartElement())
     {
         found = true;


### PR DESCRIPTION
The existing axis calibration just clipped the allowed axis values to a
given maximum. Replace this with linear offset and gain calibration.
Calibration is applied when queueing pending events so that all
following calculations receive corrected values.
Replace the existing "clipping" steps with the previously uncalibrated
case - clipping to the global minimum/maximum value.

Implement an interactive calibration workflow which
automatically detects when enough data was collected by evaluation
statistic properties. The current estimated calibration values are shown
live in red and turn black if the relative error is below 1%.
If not enough values are collected after 30 seconds, time out and
continue with the available data. This avoids long calibration times
that may lead to bug reports because users think it hangs in case of
noisy devices. Determine the final calibration values with a linear regression.

Rework the calibration dialog, e.g remove redundant ProgressBars and
reduce empty space. The new dialog is also ready to be extended for
sensor calibration.

Should also help with #407.