### PR TITLE
Implement modifier button threshold zone

### DIFF
--- a/src/globalvariables.cpp
+++ b/src/globalvariables.cpp
@@ -177,6 +177,8 @@ const double GlobalVariables::JoyControlStick::PI = acos(-1.0);
 // Set default values used for stick properties.
 const int GlobalVariables::JoyControlStick::DEFAULTDEADZONE = 8000;
 const int GlobalVariables::JoyControlStick::DEFAULTMAXZONE = GlobalVariables::GameControllerTrigger::AXISMAXZONE;
+const int GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONE = 8000;
+const bool GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONEINVERTED = false;
 const int GlobalVariables::JoyControlStick::DEFAULTDIAGONALRANGE = 45;
 const double GlobalVariables::JoyControlStick::DEFAULTCIRCLE = 0.0;
 const int GlobalVariables::JoyControlStick::DEFAULTSTICKDELAY = 0;

--- a/src/globalvariables.h
+++ b/src/globalvariables.h
@@ -203,6 +203,8 @@ class JoyControlStick
     // Define default values for stick properties.
     static const int DEFAULTDEADZONE;
     static const int DEFAULTMAXZONE;
+    static const int DEFAULTMODIFIERZONE;
+    static const bool DEFAULTMODIFIERZONEINVERTED;
     static const int DEFAULTDIAGONALRANGE;
     static const double DEFAULTCIRCLE;
     static const int DEFAULTSTICKDELAY;

--- a/src/gui/joycontrolstickeditdialog.cpp
+++ b/src/gui/joycontrolstickeditdialog.cpp
@@ -61,6 +61,10 @@ JoyControlStickEditDialog::JoyControlStickEditDialog(JoyControlStick *stick, boo
     ui->maxZoneSlider->setValue(stick->getMaxZone());
     ui->maxZoneSpinBox->setValue(stick->getMaxZone());
 
+    ui->modifierZoneSlider->setValue(stick->getModifierZone());
+    ui->modifierZoneSpinBox->setValue(stick->getModifierZone());
+    ui->modifierZoneInvertedCheckBox->setCheckState(stick->getModifierZoneInverted() ? Qt::Checked : Qt::Unchecked);
+
     ui->diagonalRangeSlider->setValue(stick->getDiagonalRange());
     ui->diagonalRangeSpinBox->setValue(stick->getDiagonalRange());
 
@@ -170,6 +174,13 @@ JoyControlStickEditDialog::JoyControlStickEditDialog(JoyControlStick *stick, boo
     connect(ui->modifierPushButton, &QPushButton::clicked, this, &JoyControlStickEditDialog::openModifierEditDialog);
     connect(stick->getModifierButton(), &JoyControlStickModifierButton::slotsChanged, this,
             &JoyControlStickEditDialog::changeModifierSummary);
+    connect(ui->modifierZoneSlider, &QSlider::valueChanged, ui->modifierZoneSpinBox, &QSpinBox::setValue);
+    connect(ui->modifierZoneSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui->modifierZoneSlider,
+            &QSlider::setValue);
+    connect(ui->modifierZoneSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), stick,
+            &JoyControlStick::setModifierZone);
+    connect(ui->modifierZoneInvertedCheckBox, &QCheckBox::stateChanged, stick,
+            [stick](int state) { stick->setModifierZoneInverted(state == Qt::Checked); });
 }
 
 // for tests

--- a/src/gui/joycontrolstickeditdialog.ui
+++ b/src/gui/joycontrolstickeditdialog.ui
@@ -525,6 +525,13 @@ functionality to an analog stick.</string>
            </property>
           </widget>
          </item>
+         <item row="16" column="0">
+          <widget class="QLabel" name="modifierZoneLabel">
+           <property name="text">
+            <string>Modifier Zone:</string>
+           </property>
+          </widget>
+         </item>
          <item row="12" column="2">
           <widget class="QDoubleSpinBox" name="stickDelayDoubleSpinBox">
            <property name="toolTip">
@@ -617,6 +624,35 @@ functionality to an analog stick.</string>
            </property>
           </widget>
          </item>
+         <item row="16" column="1">
+          <widget class="QSlider" name="modifierZoneSlider">
+           <property name="toolTip">
+            <string>Threshold at which the modifier button gets activated.
+
+This button is useful for assigning zones with
+modifier keys that can be used to assign walk/run
+functionality to an analog stick.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>32737</number>
+           </property>
+           <property name="singleStep">
+            <number>100</number>
+           </property>
+           <property name="pageStep">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>6000</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
          <item row="6" column="2">
           <widget class="QSpinBox" name="maxZoneSpinBox">
            <property name="toolTip">
@@ -664,6 +700,26 @@ functionality to an analog stick.</string>
            </property>
           </widget>
          </item>
+         <item row="16" column="2">
+          <widget class="QSpinBox" name="modifierZoneSpinBox">
+           <property name="toolTip">
+            <string>Threshold at which the modifier button gets activated.
+
+This button is useful for assigning zones with
+modifier keys that can be used to assign walk/run
+functionality to an analog stick.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>32737</number>
+           </property>
+           <property name="value">
+            <number>6000</number>
+           </property>
+          </widget>
+         </item>
          <item row="10" column="1">
           <widget class="QSlider" name="squareStickSlider">
            <property name="toolTip">
@@ -705,6 +761,20 @@ functionality to an analog stick.</string>
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="1">
+          <widget class="QCheckBox" name="modifierZoneInvertedCheckBox">
+           <property name="toolTip">
+            <string>Defines if the modifier buttons gets activated when the stick is inside or outside the threshold value.
+
+This button is useful for assigning zones with
+modifier keys that can be used to assign walk/run
+functionality to an analog stick.</string>
+           </property>
+           <property name="text">
+            <string>Invert Modifier Zone</string>
            </property>
           </widget>
          </item>

--- a/src/gui/joycontrolstickeditdialog.ui
+++ b/src/gui/joycontrolstickeditdialog.ui
@@ -37,12 +37,12 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_10">
+    <layout class="QHBoxLayout" name="mainHorizontalLayout">
      <property name="spacing">
       <number>20</number>
      </property>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QVBoxLayout" name="leftVerticalLayout" stretch="2,0,0,1">
        <item>
         <widget class="JoyControlStickStatusBox" name="stickStatusBoxWidget" native="true">
          <property name="sizePolicy">
@@ -83,84 +83,19 @@
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Minimum</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>20</height>
+           <height>32</height>
           </size>
          </property>
         </spacer>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_8">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Distance:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Y:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="xCoordinateLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>X:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="yCoordinateLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
+        <layout class="QGridLayout" name="stickReadingsLayout">
+         <item row="3" column="2">
           <widget class="QLabel" name="diagonalLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -173,8 +108,21 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QLabel" name="distanceLabel">
+         <item row="4" column="2">
+          <widget class="QLabel" name="fromSafeZoneValueLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="yCoordinateLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -199,6 +147,45 @@
            </property>
           </widget>
          </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="xCoordinateLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="distanceLabel_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Distance:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="yHeaderLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Y:</string>
+           </property>
+          </widget>
+         </item>
          <item row="4" column="0">
           <widget class="QLabel" name="fromSafeZoneLabel">
            <property name="sizePolicy">
@@ -212,8 +199,21 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
-          <widget class="QLabel" name="fromSafeZoneValueLabel">
+         <item row="0" column="0">
+          <widget class="QLabel" name="xHeaderLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>X:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="distanceLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -233,12 +233,12 @@
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Minimum</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>20</height>
+           <height>32</height>
           </size>
          </property>
         </spacer>
@@ -246,97 +246,107 @@
       </layout>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Minimum</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>16</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="widgetsVerticalLayout">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_7">
+        <layout class="QGridLayout" name="topGrid">
          <property name="spacing">
-          <number>10</number>
+          <number>4</number>
          </property>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Presets:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="presetsComboBox">
-             <property name="minimumSize">
-              <size>
-               <width>282</width>
-               <height>0</height>
-              </size>
-             </property>
-             <item>
-              <property name="text">
-               <string/>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Mouse (Normal)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Mouse (Inverted Horizontal)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Mouse (Inverted Vertical)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Mouse (Inverted Horizontal + Vertical)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Arrows</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Keys: W | A | S | D</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>NumPad</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>None</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
+         <item row="0" column="0">
+          <widget class="QLabel" name="presetsLabel">
+           <property name="text">
+            <string>Presets:</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_13">
+         <item row="0" column="1">
+          <widget class="QComboBox" name="presetsComboBox">
+           <property name="minimumSize">
+            <size>
+             <width>282</width>
+             <height>0</height>
+            </size>
+           </property>
            <item>
-            <widget class="QLabel" name="label_11">
-             <property name="text">
-              <string>Stick Mode:</string>
-             </property>
-            </widget>
+            <property name="text">
+             <string/>
+            </property>
            </item>
            <item>
-            <widget class="QComboBox" name="joyModeComboBox">
-             <property name="minimumSize">
-              <size>
-               <width>282</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Standard: 8 region stick with two direction buttons active
+            <property name="text">
+             <string>Mouse (Normal)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mouse (Inverted Horizontal)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mouse (Inverted Vertical)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mouse (Inverted Horizontal + Vertical)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Arrows</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Keys: W | A | S | D</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>NumPad</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>None</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="stickModeLabel">
+           <property name="text">
+            <string>Stick Mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="joyModeComboBox">
+           <property name="minimumSize">
+            <size>
+             <width>282</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Standard: 8 region stick with two direction buttons active
 when the stick is in a diagonal region.
 
 Eight Way: 8 region stick with each direction having its
@@ -348,30 +358,28 @@ the cardinal directions of the stick. Useful for menus.
 
 4 Way Diagonal: 4 region stick with each region corresponding
 to a diagonal zone of the stick.</string>
-             </property>
-             <item>
-              <property name="text">
-               <string>Standard</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Eight Way</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>4 Way Cardinal</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>4 Way Diagonal</string>
-              </property>
-             </item>
-            </widget>
+           </property>
+           <item>
+            <property name="text">
+             <string>Standard</string>
+            </property>
            </item>
-          </layout>
+           <item>
+            <property name="text">
+             <string>Eight Way</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>4 Way Cardinal</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>4 Way Diagonal</string>
+            </property>
+           </item>
+          </widget>
          </item>
         </layout>
        </item>
@@ -381,350 +389,345 @@ to a diagonal zone of the stick.</string>
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Minimum</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>20</height>
+           <height>32</height>
           </size>
          </property>
         </spacer>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <layout class="QGridLayout" name="middleGrid">
          <property name="spacing">
-          <number>6</number>
+          <number>4</number>
          </property>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Dead Zone:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSlider" name="deadZoneSlider">
-             <property name="toolTip">
-              <string>Dead zone value to use for an analog stick.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>32737</number>
-             </property>
-             <property name="singleStep">
-              <number>100</number>
-             </property>
-             <property name="pageStep">
-              <number>1000</number>
-             </property>
-             <property name="value">
-              <number>6000</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="deadZoneSpinBox">
-             <property name="toolTip">
-              <string>Dead zone value to use for an analog stick.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>32737</number>
-             </property>
-             <property name="value">
-              <number>8000</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="14" column="0">
+          <widget class="QLabel" name="modifierLabel">
+           <property name="text">
+            <string>Modifier:</string>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QLabel" name="label_9">
-             <property name="text">
-              <string>Max Zone:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSlider" name="maxZoneSlider">
-             <property name="toolTip">
-              <string>Value when an analog stick is considered moved 100%.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>32737</number>
-             </property>
-             <property name="singleStep">
-              <number>100</number>
-             </property>
-             <property name="pageStep">
-              <number>1000</number>
-             </property>
-             <property name="value">
-              <number>32000</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="maxZoneSpinBox">
-             <property name="toolTip">
-              <string>Value when an analog stick is considered moved 100%.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>32737</number>
-             </property>
-             <property name="value">
-              <number>32000</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="8" column="2">
+          <widget class="QSpinBox" name="diagonalRangeSpinBox">
+           <property name="toolTip">
+            <string>The area (in degrees) that each diagonal region occupies.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>90</number>
+           </property>
+           <property name="value">
+            <number>90</number>
+           </property>
+          </widget>
          </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_12">
-           <item>
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Diagonal Range:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSlider" name="diagonalRangeSlider">
-             <property name="toolTip">
-              <string>The area (in degrees) that each diagonal region occupies.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>90</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="diagonalRangeSpinBox">
-             <property name="toolTip">
-              <string>The area (in degrees) that each diagonal region occupies.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>90</number>
-             </property>
-             <property name="value">
-              <number>90</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_14">
-           <item>
-            <widget class="QLabel" name="squareStickLabel">
-             <property name="text">
-              <string>Square Stick:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSlider" name="squareStickSlider">
-             <property name="toolTip">
-              <string>Percentage to modify a square stick coordinates to confine values to a circle</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="pageStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-             <property name="sliderPosition">
-              <number>0</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="squareStickSpinBox">
-             <property name="toolTip">
-              <string>Percentage to modify a square stick coordinates to confine values to a circle</string>
-             </property>
-             <property name="suffix">
-              <string>%</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_15">
-           <item>
-            <widget class="QLabel" name="stickDelayTitleLabel">
-             <property name="text">
-              <string>Stick Delay:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSlider" name="stickDelaySlider">
-             <property name="toolTip">
-              <string>Time lapsed before a direction change is taken into effect.</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="pageStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-             <property name="sliderPosition">
-              <number>0</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
-             </property>
-             <property name="tickInterval">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QDoubleSpinBox" name="stickDelayDoubleSpinBox">
-             <property name="toolTip">
-              <string>Time lapsed before a direction change is taken into effect.</string>
-             </property>
-             <property name="readOnly">
-              <bool>false</bool>
-             </property>
-             <property name="suffix">
-              <string> s</string>
-             </property>
-             <property name="decimals">
-              <number>2</number>
-             </property>
-             <property name="maximum">
-              <double>1.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.010000000000000</double>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="modifierHorizontalLayout">
-           <property name="topMargin">
+         <item row="12" column="1">
+          <widget class="QSlider" name="stickDelaySlider">
+           <property name="toolTip">
+            <string>Time lapsed before a direction change is taken into effect.</string>
+           </property>
+           <property name="minimum">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Modifier:</string>
-             </property>
-            </widget>
-           </item>
-           <item alignment="Qt::AlignVCenter">
-            <widget class="QPushButton" name="modifierPushButton">
-             <property name="toolTip">
-              <string>Edit button that is active while the stick is active.
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="pageStep">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+           <property name="sliderPosition">
+            <number>0</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+           <property name="tickInterval">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="squareStickLabel">
+           <property name="text">
+            <string>Square Stick:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="diagonalRangeLabel">
+           <property name="text">
+            <string>Diagonal Range:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="2">
+          <widget class="QSpinBox" name="squareStickSpinBox">
+           <property name="toolTip">
+            <string>Percentage to modify a square stick coordinates to confine values to a circle</string>
+           </property>
+           <property name="suffix">
+            <string>%</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="deadZoneLabel">
+           <property name="text">
+            <string>Dead Zone:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="maxZoneLabel">
+           <property name="text">
+            <string>Max Zone:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="2">
+          <widget class="QPushButton" name="modifierPushButton">
+           <property name="toolTip">
+            <string>Edit button that is active while the stick is active.
 
 This button is useful for assigning zones with
 modifier keys that can be used to assign walk/run
 functionality to an analog stick.</string>
-             </property>
-             <property name="text">
-              <string>PushButton</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+           </property>
+           <property name="text">
+            <string>PushButton</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="2">
+          <widget class="QDoubleSpinBox" name="stickDelayDoubleSpinBox">
+           <property name="toolTip">
+            <string>Time lapsed before a direction change is taken into effect.</string>
+           </property>
+           <property name="readOnly">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string> s</string>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QSpinBox" name="deadZoneSpinBox">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Dead zone value to use for an analog stick.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>32737</number>
+           </property>
+           <property name="value">
+            <number>6000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="1">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Minimum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>32</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="12" column="0">
+          <widget class="QLabel" name="stickDelayTitleLabel">
+           <property name="text">
+            <string>Stick Delay:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QSlider" name="maxZoneSlider">
+           <property name="toolTip">
+            <string>Value when an analog stick is considered moved 100%.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>32737</number>
+           </property>
+           <property name="singleStep">
+            <number>100</number>
+           </property>
+           <property name="pageStep">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>32000</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="QSpinBox" name="maxZoneSpinBox">
+           <property name="toolTip">
+            <string>Value when an analog stick is considered moved 100%.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>32737</number>
+           </property>
+           <property name="value">
+            <number>32000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSlider" name="deadZoneSlider">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Dead zone value to use for an analog stick.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>32737</number>
+           </property>
+           <property name="singleStep">
+            <number>100</number>
+           </property>
+           <property name="pageStep">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>6000</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QSlider" name="squareStickSlider">
+           <property name="toolTip">
+            <string>Percentage to modify a square stick coordinates to confine values to a circle</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="pageStep">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+           <property name="sliderPosition">
+            <number>0</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QSlider" name="diagonalRangeSlider">
+           <property name="toolTip">
+            <string>The area (in degrees) that each diagonal region occupies.</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>90</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Minimum</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>20</height>
+           <height>32</height>
           </size>
          </property>
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <property name="spacing">
-          <number>10</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
+        <layout class="QHBoxLayout" name="nameHorizontalLayout">
          <item>
           <widget class="QLabel" name="stickNameLabel">
            <property name="text">
@@ -734,6 +737,19 @@ functionality to an analog stick.</string>
             <cstring>stickNameLineEdit</cstring>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
          <item>
           <widget class="QLineEdit" name="stickNameLineEdit">

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -830,6 +830,8 @@ void JoyControlStick::reset()
 {
     deadZone = GlobalVariables::JoyControlStick::DEFAULTDEADZONE;
     maxZone = GlobalVariables::JoyAxis::AXISMAXZONE;
+    m_modifier_zone = GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONE;
+    m_modifier_zone_inverted = GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONEINVERTED;
     diagonalRange = GlobalVariables::JoyControlStick::DEFAULTDIAGONALRANGE;
     isActive = false;
     pendingStickEvent = false;
@@ -1816,6 +1818,8 @@ bool JoyControlStick::isDefault()
     bool value = true;
     value = value && (deadZone == GlobalVariables::JoyControlStick::DEFAULTDEADZONE);
     value = value && (maxZone == GlobalVariables::JoyControlStick::DEFAULTMAXZONE);
+    value = value && (m_modifier_zone == GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONE);
+    value = value && (m_modifier_zone_inverted == GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONEINVERTED);
     value = value && (diagonalRange == GlobalVariables::JoyControlStick::DEFAULTDIAGONALRANGE);
     value = value && (currentMode == DEFAULTMODE);
     value = value && qFuzzyCompare(circle, GlobalVariables::JoyControlStick::DEFAULTCIRCLE);
@@ -2638,6 +2642,8 @@ void JoyControlStick::copyAssignments(JoyControlStick *destStick)
     destStick->reset();
     destStick->deadZone = deadZone;
     destStick->maxZone = maxZone;
+    destStick->m_modifier_zone = m_modifier_zone;
+    destStick->m_modifier_zone_inverted = m_modifier_zone_inverted;
     destStick->diagonalRange = diagonalRange;
     destStick->currentDirection = currentDirection;
     destStick->currentMode = currentMode;

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -998,6 +998,16 @@ void JoyControlStick::readConfig(QXmlStreamReader *xml)
                 QString temptext = xml->readElementText();
                 int tempchoice = temptext.toInt();
                 this->setMaxZone(tempchoice);
+            } else if ((xml->name() == "modifierZone") && xml->isStartElement())
+            {
+                QString temptext = xml->readElementText();
+                int tempchoice = temptext.toInt();
+                setModifierZone(tempchoice);
+            } else if ((xml->name() == "modifierZoneInverted") && xml->isStartElement())
+            {
+                QString temptext = xml->readElementText();
+                int tempchoice = temptext.toInt();
+                setModifierZoneInverted(tempchoice);
             } else if ((xml->name() == "diagonalRange") && xml->isStartElement())
             {
                 QString temptext = xml->readElementText();
@@ -1072,6 +1082,12 @@ void JoyControlStick::writeConfig(QXmlStreamWriter *xml)
 
         if (maxZone != GlobalVariables::JoyControlStick::DEFAULTMAXZONE)
             xml->writeTextElement("maxZone", QString::number(maxZone));
+
+        if (m_modifier_zone != GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONE)
+            xml->writeTextElement("modifierZone", QString::number(m_modifier_zone));
+
+        if (m_modifier_zone_inverted != GlobalVariables::JoyControlStick::DEFAULTMODIFIERZONEINVERTED)
+            xml->writeTextElement("modifierZoneInverted", QString::number(m_modifier_zone_inverted));
 
         if ((currentMode == StandardMode || currentMode == EightWayMode) &&
             (diagonalRange != GlobalVariables::JoyControlStick::DEFAULTDIAGONALRANGE))

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -271,16 +271,23 @@ void JoyControlStick::createDeskEvent(bool ignoresets)
         performButtonRelease(activeButton3, ignoresets);
     }
 
-    if (safezone)
+    // Activate modifier button before activating directional buttons.
+    // Value from the new stick event will be used to determine
+    // distance events.
+    // Release modifier button after releasing directional buttons.
+    double distance = getAbsoluteRawDistance();
+    if (m_modifier_zone_inverted)
     {
-        // Activate modifier button before activating directional buttons.
-        // Value from the new stick event will be used to determine
-        // distance events.
-        modifierButton->joyEvent(true, ignoresets);
+        if (safezone && distance < m_modifier_zone)
+            modifierButton->joyEvent(true, ignoresets);
+        else
+            modifierButton->joyEvent(false, ignoresets);
     } else
     {
-        // Release modifier button after releasing directional buttons.
-        modifierButton->joyEvent(false, ignoresets);
+        if (safezone && distance > m_modifier_zone)
+            modifierButton->joyEvent(true, ignoresets);
+        else
+            modifierButton->joyEvent(false, ignoresets);
     }
 
     /*

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -828,9 +828,9 @@ int JoyControlStick::getCurrentlyAssignedSet() { return originset; }
 
 void JoyControlStick::reset()
 {
-    deadZone = 8000;
+    deadZone = GlobalVariables::JoyControlStick::DEFAULTDEADZONE;
     maxZone = GlobalVariables::JoyAxis::AXISMAXZONE;
-    diagonalRange = 45;
+    diagonalRange = GlobalVariables::JoyControlStick::DEFAULTDIAGONALRANGE;
     isActive = false;
     pendingStickEvent = false;
 

--- a/src/joycontrolstick.cpp
+++ b/src/joycontrolstick.cpp
@@ -824,6 +824,17 @@ QString JoyControlStick::getDefaultStickName() { return defaultStickName; }
 
 int JoyControlStick::getMaxZone() { return maxZone; }
 
+/**
+ * @brief Returns the modifier zone of the stick
+ */
+int JoyControlStick::getModifierZone() const { return m_modifier_zone; }
+
+/**
+ * @brief Checks if the modifier zone of this stick is inverted
+ * @returns True if the modifier zone is inverted, false otherwise
+ */
+bool JoyControlStick::getModifierZoneInverted() const { return m_modifier_zone_inverted; }
+
 int JoyControlStick::getCurrentlyAssignedSet() { return originset; }
 
 void JoyControlStick::reset()
@@ -869,6 +880,36 @@ void JoyControlStick::setMaxZone(int value)
     {
         maxZone = value;
         emit maxZoneChanged(value);
+        emit propertyUpdated();
+    }
+}
+
+/**
+ * @brief Sets the modifier zone of the stick to the given value
+ * @param[in] value New stick modifier zone
+ */
+void JoyControlStick::setModifierZone(int value)
+{
+    value = std::min(abs(value), GlobalVariables::JoyAxis::AXISMAX);
+
+    if ((value != m_modifier_zone) && (value < maxZone) && (value > deadZone))
+    {
+        m_modifier_zone = value;
+        emit modifierZoneChanged(value);
+        emit propertyUpdated();
+    }
+}
+
+/**
+ * @brief Inverts the direction of the modifier zone of the stick.
+ * @param[in] value True if the zone should be inverted, false otherwise.
+ */
+void JoyControlStick::setModifierZoneInverted(bool value)
+{
+    if (value != m_modifier_zone_inverted)
+    {
+        m_modifier_zone_inverted = value;
+        emit modifierZoneChanged(m_modifier_zone);
         emit propertyUpdated();
     }
 }

--- a/src/joycontrolstick.h
+++ b/src/joycontrolstick.h
@@ -268,6 +268,8 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
   private:
     int originset;
     int deadZone;
+    int m_modifier_zone;
+    bool m_modifier_zone_inverted;
     int diagonalRange;
     int maxZone;
     int index;

--- a/src/joycontrolstick.h
+++ b/src/joycontrolstick.h
@@ -72,6 +72,8 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     int getIndex();
     int getRealJoyIndex();
     int getMaxZone();
+    int getModifierZone() const;
+    bool getModifierZoneInverted() const;
     int getCurrentlyAssignedSet();
     int getXCoordinate();
     int getYCoordinate();
@@ -243,6 +245,7 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     void deadZoneChanged(int value);
     void diagonalRangeChanged(int value);
     void maxZoneChanged(int value);
+    void modifierZoneChanged(int value);
     void circleAdjustChange(double circle);
     void stickDelayChanged(int value);
     void stickNameChanged();
@@ -253,6 +256,8 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     void reset();
     void setDeadZone(int value);
     void setMaxZone(int value);
+    void setModifierZone(int value);
+    void setModifierZoneInverted(bool value);
     void setDiagonalRange(int value);
     void setStickName(QString tempName);
     void setButtonsSpringRelativeStatus(bool value);

--- a/src/joycontrolstick.h
+++ b/src/joycontrolstick.h
@@ -237,13 +237,13 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
     void clearPendingAxisEvents(); // JoyControlStickEvent class
 
   signals:
-    void moved(int xaxis, int yaxis);       // JoyControlStickAxes class
-    void active(int xaxis, int yaxis);      // JoyControlStickAxes class
-    void released(int axis, int yaxis);     // JoyControlStickAxes class
-    void deadZoneChanged(int value);        // JoyControlStickAxes class
-    void diagonalRangeChanged(int value);   // JoyControlStickAxes class
-    void maxZoneChanged(int value);         // JoyControlStickAxes class
-    void circleAdjustChange(double circle); // JoyControlStickAxes class
+    void moved(int xaxis, int yaxis);
+    void active(int xaxis, int yaxis);
+    void released(int axis, int yaxis);
+    void deadZoneChanged(int value);
+    void diagonalRangeChanged(int value);
+    void maxZoneChanged(int value);
+    void circleAdjustChange(double circle);
     void stickDelayChanged(int value);
     void stickNameChanged();
     void joyModeChanged();
@@ -251,9 +251,9 @@ class JoyControlStick : public QObject, public JoyStickDirectionsType
 
   public slots:
     void reset();
-    void setDeadZone(int value);      // JoyControlStickAxes class
-    void setMaxZone(int value);       // JoyControlStickAxes class
-    void setDiagonalRange(int value); // JoyControlStickAxes class
+    void setDeadZone(int value);
+    void setMaxZone(int value);
+    void setDiagonalRange(int value);
     void setStickName(QString tempName);
     void setButtonsSpringRelativeStatus(bool value);
     void setCircleAdjust(double circle); // JoyControlStickAxes class

--- a/src/joycontrolstickstatusbox.cpp
+++ b/src/joycontrolstickstatusbox.cpp
@@ -30,6 +30,7 @@
 #include <QList>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QSizePolicy>
 
 JoyControlStickStatusBox::JoyControlStickStatusBox(QWidget *parent)
@@ -53,6 +54,7 @@ void JoyControlStickStatusBox::setStick(JoyControlStick *stick)
         disconnect(stick, SIGNAL(moved(int, int)), this, nullptr);
         disconnect(stick, SIGNAL(diagonalRangeChanged(int)), this, nullptr);
         disconnect(stick, SIGNAL(maxZoneChanged(int)), this, nullptr);
+        disconnect(stick, SIGNAL(modifierZoneChanged(int)), this, nullptr);
         disconnect(stick, SIGNAL(joyModeChanged()), this, nullptr);
         disconnect(stick, SIGNAL(circleAdjustChange(double)), this, nullptr);
     }
@@ -62,6 +64,7 @@ void JoyControlStickStatusBox::setStick(JoyControlStick *stick)
     connect(stick, SIGNAL(moved(int, int)), this, SLOT(update()));
     connect(stick, SIGNAL(diagonalRangeChanged(int)), this, SLOT(update()));
     connect(stick, SIGNAL(maxZoneChanged(int)), this, SLOT(update()));
+    connect(stick, SIGNAL(modifierZoneChanged(int)), this, SLOT(update()));
     connect(stick, SIGNAL(joyModeChanged()), this, SLOT(update()));
     connect(stick, SIGNAL(circleAdjustChange(double)), this, SLOT(update()));
 
@@ -145,11 +148,32 @@ void JoyControlStickStatusBox::drawEightWayBox()
         painter.drawPie(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
                         GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2,
                         static_cast<int>(anglesList.value(8)) * 16, diagonalRange * 16);
+
+        // Draw modifier zone circle
+        int modifierZone = m_stick->getModifierZone();
+        int maxZone = m_stick->getMaxZone();
+        penny.setWidth(0);
+        penny.setColor(Qt::blue);
+        painter.setOpacity(0.5);
+        painter.setPen(penny);
+        painter.setBrush(QBrush(Qt::yellow));
+
+        if (m_stick->getModifierZoneInverted())
+        {
+            painter.drawEllipse(-modifierZone, -modifierZone, modifierZone * 2, modifierZone * 2);
+        } else
+        {
+            QPainterPath modifierZonePath;
+            modifierZonePath.addEllipse(QPoint(0, 0), maxZone, maxZone);
+            modifierZonePath.addEllipse(QPoint(0, 0), modifierZone, modifierZone);
+            painter.drawPath(modifierZonePath);
+        }
     }
 
     // Draw deadzone circle
     penny.setWidth(0);
     penny.setColor(Qt::blue);
+    painter.setOpacity(1);
     painter.setPen(penny);
     painter.setBrush(QBrush(Qt::red));
     int deadZone = m_stick != nullptr ? m_stick->getDeadZone() : 0;
@@ -275,9 +299,9 @@ void JoyControlStickStatusBox::drawFourWayCardinalBox()
     painter.drawEllipse(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
                         GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2);
 
-    // Draw diagonal zones
     if (m_stick != nullptr)
     {
+        // Draw diagonal zones
         QList<int> anglesList = m_stick->getFourWayCardinalZoneAngles();
         penny.setWidth(0);
         penny.setColor(Qt::black);
@@ -293,6 +317,26 @@ void JoyControlStickStatusBox::drawFourWayCardinalBox()
                         anglesList.value(3) * 16, 90 * 16);
 
         painter.setOpacity(1.0);
+
+        // Draw modifier zone circle
+        int modifierZone = m_stick->getModifierZone();
+        int maxZone = m_stick->getMaxZone();
+        penny.setWidth(0);
+        penny.setColor(Qt::blue);
+        painter.setOpacity(0.5);
+        painter.setPen(penny);
+        painter.setBrush(QBrush(Qt::yellow));
+
+        if (m_stick->getModifierZoneInverted())
+        {
+            painter.drawEllipse(-modifierZone, -modifierZone, modifierZone * 2, modifierZone * 2);
+        } else
+        {
+            QPainterPath modifierZonePath;
+            modifierZonePath.addEllipse(QPoint(0, 0), maxZone, maxZone);
+            modifierZonePath.addEllipse(QPoint(0, 0), modifierZone, modifierZone);
+            painter.drawPath(modifierZonePath);
+        }
     }
 
     // Draw deadzone circle
@@ -424,9 +468,9 @@ void JoyControlStickStatusBox::drawFourWayDiagonalBox()
     painter.drawEllipse(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
                         GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2);
 
-    // Draw diagonal zones
     if (m_stick != nullptr)
     {
+        // Draw diagonal zones
         QList<int> anglesList = m_stick->getFourWayDiagonalZoneAngles();
         penny.setWidth(0);
         penny.setColor(Qt::black);
@@ -442,6 +486,26 @@ void JoyControlStickStatusBox::drawFourWayDiagonalBox()
                         anglesList.value(3) * 16, 90 * 16);
 
         painter.setOpacity(1.0);
+
+        // Draw modifier zone circle
+        int modifierZone = m_stick->getModifierZone();
+        int maxZone = m_stick->getMaxZone();
+        penny.setWidth(0);
+        penny.setColor(Qt::blue);
+        painter.setOpacity(0.5);
+        painter.setPen(penny);
+        painter.setBrush(QBrush(Qt::yellow));
+
+        if (m_stick->getModifierZoneInverted())
+        {
+            painter.drawEllipse(-modifierZone, -modifierZone, modifierZone * 2, modifierZone * 2);
+        } else
+        {
+            QPainterPath modifierZonePath;
+            modifierZonePath.addEllipse(QPoint(0, 0), maxZone, maxZone);
+            modifierZonePath.addEllipse(QPoint(0, 0), modifierZone, modifierZone);
+            painter.drawPath(modifierZonePath);
+        }
     }
 
     // Draw deadzone circle

--- a/src/joycontrolstickstatusbox.cpp
+++ b/src/joycontrolstickstatusbox.cpp
@@ -107,17 +107,20 @@ void JoyControlStickStatusBox::drawEightWayBox()
     QPainter painter(&pix);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    // Draw box outline
+    // Draw outline circle
     QPen penny;
     penny.setColor(Qt::black);
-    penny.setWidth(1);
+    penny.setWidth(0);
+    painter.setPen(penny);
     painter.setBrush(Qt::NoBrush);
-    painter.drawRect(0, 0, side - 1, side - 1);
 
     painter.save();
     painter.scale(side / static_cast<double>(GlobalVariables::JoyAxis::AXISMAX * 2.0),
                   side / static_cast<double>(GlobalVariables::JoyAxis::AXISMAX * 2.0));
     painter.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
+
+    painter.drawEllipse(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2);
 
     // Draw diagonal zones
     if (m_stick != nullptr)
@@ -257,17 +260,20 @@ void JoyControlStickStatusBox::drawFourWayCardinalBox()
     QPainter painter(&pix);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    // Draw box outline
+    // Draw outline circle
     QPen penny;
     penny.setColor(Qt::black);
-    penny.setWidth(1);
+    penny.setWidth(0);
+    painter.setPen(penny);
     painter.setBrush(Qt::NoBrush);
-    painter.drawRect(0, 0, side - 1, side - 1);
 
     painter.save();
     painter.scale(side / static_cast<double>(GlobalVariables::JoyAxis::AXISMAX * 2.0),
                   side / static_cast<double>(GlobalVariables::JoyAxis::AXISMAX * 2.0));
     painter.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
+
+    painter.drawEllipse(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2);
 
     // Draw diagonal zones
     if (m_stick != nullptr)
@@ -403,17 +409,20 @@ void JoyControlStickStatusBox::drawFourWayDiagonalBox()
     QPainter painter(&pix);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    // Draw box outline
+    // Draw outline circle
     QPen penny;
     penny.setColor(Qt::black);
-    penny.setWidth(1);
+    penny.setWidth(0);
+    painter.setPen(penny);
     painter.setBrush(Qt::NoBrush);
-    painter.drawRect(0, 0, side - 1, side - 1);
 
     painter.save();
     painter.scale(side / static_cast<double>(GlobalVariables::JoyAxis::AXISMAX * 2.0),
                   side / static_cast<double>(GlobalVariables::JoyAxis::AXISMAX * 2.0));
     painter.translate(GlobalVariables::JoyAxis::AXISMAX, GlobalVariables::JoyAxis::AXISMAX);
+
+    painter.drawEllipse(-GlobalVariables::JoyAxis::AXISMAX, -GlobalVariables::JoyAxis::AXISMAX,
+                        GlobalVariables::JoyAxis::AXISMAX * 2, GlobalVariables::JoyAxis::AXISMAX * 2);
 
     // Draw diagonal zones
     if (m_stick != nullptr)


### PR DESCRIPTION
Adds a configurable threshold zone to the existing modifier key in the control stick edit dialog.
This allows mapping the analog range of a stick to walk/run in game without an extra spring button.

Closes #310