### PR TITLE
Allow storing calibration for multiple controllers in a profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(antimicrox_SOURCES
         src/inputdaemon.cpp
         src/inputdevice.cpp
         src/inputdevicebitarraystatus.cpp
+        src/inputdevicecalibration.cpp
         src/joyaccelerometersensor.cpp
         src/joyaxis.cpp
         src/joyaxiscontextmenu.cpp
@@ -300,6 +301,7 @@ set(antimicrox_HEADERS
         src/inputdaemon.h
         src/inputdevice.h
         src/inputdevicebitarraystatus.h
+        src/inputdevicecalibration.h
         src/joyaccelerometersensor.h
         src/joyaxis.h
         src/joyaxiscontextmenu.h

--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -77,6 +77,19 @@ QString GameController::getVendorString() const { return getRawVendorString(); }
 
 QString GameController::getProductIDString() const { return getRawProductIDString(); }
 
+QString GameController::getSerialString() const
+{
+    QString temp = QString();
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    if (controller != nullptr)
+    {
+        const char *serial = SDL_GameControllerGetSerial(controller);
+        temp = QString(serial).remove(QRegExp("[^A-Za-z0-9]"));
+    }
+#endif
+    return temp;
+}
+
 QString GameController::getUniqueIDString() const { return getRawUniqueIDString(); }
 
 QString GameController::getProductVersion() const { return getRawProductVersion(); }
@@ -151,7 +164,7 @@ QString GameController::getRawProductVersion() const
 
 QString GameController::getRawUniqueIDString() const
 {
-    return (getRawGUIDString() + getRawVendorString() + getRawProductIDString());
+    return (getRawGUIDString() + getRawVendorString() + getRawProductIDString() + getSerialString());
 }
 
 void GameController::closeSDLDevice()

--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -69,19 +69,19 @@ QString GameController::getSDLName()
     return temp;
 }
 
-QString GameController::getXmlName() { return GlobalVariables::GameController::xmlName; }
+QString GameController::getXmlName() const { return GlobalVariables::GameController::xmlName; }
 
-QString GameController::getGUIDString() { return getRawGUIDString(); }
+QString GameController::getGUIDString() const { return getRawGUIDString(); }
 
-QString GameController::getVendorString() { return getRawVendorString(); }
+QString GameController::getVendorString() const { return getRawVendorString(); }
 
-QString GameController::getProductIDString() { return getRawProductIDString(); }
+QString GameController::getProductIDString() const { return getRawProductIDString(); }
 
-QString GameController::getUniqueIDString() { return getRawUniqueIDString(); }
+QString GameController::getUniqueIDString() const { return getRawUniqueIDString(); }
 
-QString GameController::getProductVersion() { return getRawProductVersion(); }
+QString GameController::getProductVersion() const { return getRawProductVersion(); }
 
-QString GameController::getRawGUIDString()
+QString GameController::getRawGUIDString() const
 {
     QString temp = QString();
 
@@ -101,7 +101,7 @@ QString GameController::getRawGUIDString()
     return temp;
 }
 
-QString GameController::getRawVendorString()
+QString GameController::getRawVendorString() const
 {
     QString temp = QString();
 
@@ -117,7 +117,7 @@ QString GameController::getRawVendorString()
     return temp;
 }
 
-QString GameController::getRawProductIDString()
+QString GameController::getRawProductIDString() const
 {
     QString temp = QString();
 
@@ -133,7 +133,7 @@ QString GameController::getRawProductIDString()
     return temp;
 }
 
-QString GameController::getRawProductVersion()
+QString GameController::getRawProductVersion() const
 {
     QString temp = QString();
 
@@ -149,7 +149,7 @@ QString GameController::getRawProductVersion()
     return temp;
 }
 
-QString GameController::getRawUniqueIDString()
+QString GameController::getRawUniqueIDString() const
 {
     return (getRawGUIDString() + getRawVendorString() + getRawProductIDString());
 }

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -44,6 +44,7 @@ class GameController : public InputDevice
     virtual QString getGUIDString() const override;
     virtual QString getVendorString() const override;
     virtual QString getProductIDString() const override;
+    virtual QString getSerialString() const override;
     virtual QString getUniqueIDString() const override;
     virtual QString getRawGUIDString() const override;
     virtual QString getProductVersion() const override;

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -38,19 +38,19 @@ class GameController : public InputDevice
 
     virtual QString getName() override;
     virtual QString getSDLName() override;
-    virtual QString getXmlName() override;
+    virtual QString getXmlName() const override;
 
     // GUID available on SDL 2.
-    virtual QString getGUIDString() override;
-    virtual QString getVendorString() override;
-    virtual QString getProductIDString() override;
-    virtual QString getUniqueIDString() override;
-    virtual QString getProductVersion() override;
-    virtual QString getRawGUIDString() override;
-    virtual QString getRawUniqueIDString() override;
-    virtual QString getRawVendorString() override;
-    virtual QString getRawProductIDString() override;
-    virtual QString getRawProductVersion() override;
+    virtual QString getGUIDString() const override;
+    virtual QString getVendorString() const override;
+    virtual QString getProductIDString() const override;
+    virtual QString getUniqueIDString() const override;
+    virtual QString getRawGUIDString() const override;
+    virtual QString getProductVersion() const override;
+    virtual QString getRawUniqueIDString() const override;
+    virtual QString getRawVendorString() const override;
+    virtual QString getRawProductIDString() const override;
+    virtual QString getRawProductVersion() const override;
 
     virtual bool isGameController() override;
     virtual void closeSDLDevice() override;

--- a/src/gui/calibration.cpp
+++ b/src/gui/calibration.cpp
@@ -601,14 +601,14 @@ void Calibration::saveSettings()
         stickRegression(&offsetX, &gainX, m_offset[0].getMean(), m_min[0].getMean(), m_max[0].getMean());
         stickRegression(&offsetY, &gainY, m_offset[1].getMean(), m_min[1].getMean(), m_max[1].getMean());
 
-        m_joystick->applyStickCalibration(m_index, offsetX, gainX, offsetY, gainY);
+        m_joystick->updateStickCalibration(m_index, offsetX, gainX, offsetY, gainY);
         showStickCalibrationValues(true, offsetX, true, gainX, true, offsetY, true, gainY);
     } else if (m_type == CAL_ACCELEROMETER)
     {
-        m_joystick->applyAccelerometerCalibration(m_offset[0].getMean(), m_offset[1].getMean(), m_offset[2].getMean());
+        m_joystick->updateAccelerometerCalibration(m_offset[0].getMean(), m_offset[1].getMean(), m_offset[2].getMean());
     } else if (m_type == CAL_GYROSCOPE)
     {
-        m_joystick->applyGyroscopeCalibration(m_offset[0].getMean(), m_offset[1].getMean(), m_offset[2].getMean());
+        m_joystick->updateGyroscopeCalibration(m_offset[0].getMean(), m_offset[1].getMean(), m_offset[2].getMean());
     }
     m_changed = false;
     m_calibrated = true;

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1338,6 +1338,7 @@ QString InputDevice::getDescription()
                         QObject::tr("GUID:             %1").arg(getGUIDString()) + "\n  " +
                         QObject::tr("VendorID:         %1").arg(getVendorString()) + "\n  " +
                         QObject::tr("ProductID:        %1").arg(getProductIDString()) + "\n  " +
+                        QObject::tr("Serial:           %1").arg(getSerialString()) + "\n  " +
                         QObject::tr("Product Version:  %1").arg(getProductVersion()) + "\n  " +
                         QObject::tr("Name:             %1").arg(getSDLName()) + "\n";
     QString gameControllerStatus = isGameController() ? QObject::tr("Yes") : QObject::tr("No");

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1682,15 +1682,15 @@ bool InputDevice::isRelevantUniqueID(QString tempUniqueID)
     return result;
 }
 
-QString InputDevice::getRawGUIDString() { return getGUIDString(); }
+QString InputDevice::getRawGUIDString() const { return getGUIDString(); }
 
-QString InputDevice::getRawVendorString() { return getVendorString(); }
+QString InputDevice::getRawVendorString() const { return getVendorString(); }
 
-QString InputDevice::getRawProductIDString() { return getProductIDString(); }
+QString InputDevice::getRawProductIDString() const { return getProductIDString(); }
 
-QString InputDevice::getRawProductVersion() { return getProductVersion(); }
+QString InputDevice::getRawProductVersion() const { return getProductVersion(); }
 
-QString InputDevice::getRawUniqueIDString() { return getUniqueIDString(); }
+QString InputDevice::getRawUniqueIDString() const { return getUniqueIDString(); }
 
 void InputDevice::haltServices() { emit requestWait(); }
 

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1751,6 +1751,21 @@ QList<int> &InputDevice::getDpadstatesLocal() { return dpadstates; }
 SDL_Joystick *InputDevice::getJoyHandle() const { return m_joyhandle; }
 
 /**
+ * @brief Updates stored calibration for this controller and applies
+ *   calibration to the specified stick in all sets
+ *   See JoyControlStick::setCalibration
+ * @param[in] index Stick index
+ * @param[in] offsetX Offset value for X axis
+ * @param[in] gainX Gain value for X axis
+ * @param[in] offsetY Offset value for Y axis
+ * @param[in] gainY Gain value for Y axis
+ */
+void InputDevice::updateStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY)
+{
+    applyStickCalibration(index, offsetX, gainX, offsetY, gainY);
+}
+
+/**
  * @brief Applies calibration to the specified stick in all sets
  *  See JoyControlStick::setCalibration
  * @param[in] index Stick index
@@ -1776,6 +1791,18 @@ void InputDevice::applyStickCalibration(int index, double offsetX, double gainX,
  * @param[in] offsetY Offset angle around the Y axis
  * @param[in] offsetZ Offset angle around the Z axis
  */
+void InputDevice::updateAccelerometerCalibration(double offsetX, double offsetY, double offsetZ)
+{
+    applyAccelerometerCalibration(offsetX, offsetY, offsetZ);
+}
+
+/**
+ * @brief Applies calibration to the specified accelerometer in all sets
+ *  See JoySensor::setCalibration
+ * @param[in] offsetX Offset angle around the X axis
+ * @param[in] offsetY Offset angle around the Y axis
+ * @param[in] offsetZ Offset angle around the Z axis
+ */
 void InputDevice::applyAccelerometerCalibration(double offsetX, double offsetY, double offsetZ)
 {
     for (auto &set : joystick_sets)
@@ -1784,6 +1811,19 @@ void InputDevice::applyAccelerometerCalibration(double offsetX, double offsetY, 
         if (accelerometer != nullptr)
             accelerometer->setCalibration(offsetX, offsetY, offsetZ);
     }
+}
+
+/**
+ * @brief Updates stored calibration for this controller and applies
+ *   calibration to the specified gyroscope in all sets
+ *   See JoySensor::setCalibration
+ * @param[in] offsetX Offset value for X axis
+ * @param[in] offsetY Offset value for Y axis
+ * @param[in] offsetZ Offset value for Z axis
+ */
+void InputDevice::updateGyroscopeCalibration(double offsetX, double offsetY, double offsetZ)
+{
+    applyGyroscopeCalibration(offsetX, offsetY, offsetZ);
 }
 
 /**

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -37,6 +37,7 @@
 
 InputDevice::InputDevice(SDL_Joystick *joystick, int deviceIndex, AntiMicroSettings *settings, QObject *parent)
     : QObject(parent)
+    , m_calibrations(this)
 {
     buttonDownCount = 0;
     joyNumber = deviceIndex;
@@ -1749,6 +1750,11 @@ QList<int> &InputDevice::getAxesstatesLocal() { return axesstates; }
 QList<int> &InputDevice::getDpadstatesLocal() { return dpadstates; }
 
 SDL_Joystick *InputDevice::getJoyHandle() const { return m_joyhandle; }
+
+/**
+ * @brief Returns a pointer to the internal calibration storage backend.
+ */
+InputDeviceCalibration *InputDevice::getCalibrationBackend() { return &m_calibrations; }
 
 /**
  * @brief Updates stored calibration for this controller and applies

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1768,6 +1768,7 @@ InputDeviceCalibration *InputDevice::getCalibrationBackend() { return &m_calibra
  */
 void InputDevice::updateStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY)
 {
+    m_calibrations.setStickCalibration(index, offsetX, gainX, offsetY, gainY);
     applyStickCalibration(index, offsetX, gainX, offsetY, gainY);
 }
 
@@ -1799,6 +1800,7 @@ void InputDevice::applyStickCalibration(int index, double offsetX, double gainX,
  */
 void InputDevice::updateAccelerometerCalibration(double offsetX, double offsetY, double offsetZ)
 {
+    m_calibrations.setAccelerometerCalibration(offsetX, offsetY, offsetZ);
     applyAccelerometerCalibration(offsetX, offsetY, offsetZ);
 }
 
@@ -1829,6 +1831,7 @@ void InputDevice::applyAccelerometerCalibration(double offsetX, double offsetY, 
  */
 void InputDevice::updateGyroscopeCalibration(double offsetX, double offsetY, double offsetZ)
 {
+    m_calibrations.setGyroscopeCalibration(offsetX, offsetY, offsetZ);
     applyGyroscopeCalibration(offsetX, offsetY, offsetZ);
 }
 

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -19,6 +19,7 @@
 #ifndef INPUTDEVICE_H
 #define INPUTDEVICE_H
 
+#include "inputdevicecalibration.h"
 #include "joysensordirection.h"
 #include "joysensortype.h"
 #include "setjoystick.h"
@@ -149,6 +150,7 @@ class InputDevice : public QObject
     QHash<int, SetJoystick *> &getJoystick_sets();
     SDL_Joystick *getJoyHandle() const;
 
+    InputDeviceCalibration *getCalibrationBackend();
     void updateStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
     void applyStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
     void updateAccelerometerCalibration(double offsetX, double offsetY, double offsetZ);
@@ -165,6 +167,7 @@ class InputDevice : public QObject
     int rawAxisDeadZone;
     int keyPressTime; // unsigned
     QString profileName;
+    InputDeviceCalibration m_calibrations;
 
   signals:
     void setChangeActivated(int index);

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -149,8 +149,11 @@ class InputDevice : public QObject
     QHash<int, SetJoystick *> &getJoystick_sets();
     SDL_Joystick *getJoyHandle() const;
 
+    void updateStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
     void applyStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
+    void updateAccelerometerCalibration(double offsetX, double offsetY, double offsetZ);
     void applyAccelerometerCalibration(double offsetX, double offsetY, double offsetZ);
+    void updateGyroscopeCalibration(double offsetX, double offsetY, double offsetZ);
     void applyGyroscopeCalibration(double offsetX, double offsetY, double offsetZ);
 
   protected:

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -58,22 +58,22 @@ class InputDevice : public QObject
     bool isActive();
     int getButtonDownCount();
 
-    virtual QString getXmlName() = 0;
+    virtual QString getXmlName() const = 0;
     virtual QString getName() = 0;
     virtual QString getSDLName() = 0;
     virtual QString getDescription();
 
     // GUID only available on SDL 2.
-    virtual QString getGUIDString() = 0;
-    virtual QString getUniqueIDString() = 0;
-    virtual QString getVendorString() = 0;
-    virtual QString getProductIDString() = 0;
-    virtual QString getProductVersion() = 0;
-    virtual QString getRawGUIDString();
-    virtual QString getRawVendorString();
-    virtual QString getRawProductIDString();
-    virtual QString getRawProductVersion();
-    virtual QString getRawUniqueIDString();
+    virtual QString getGUIDString() const = 0;
+    virtual QString getUniqueIDString() const = 0;
+    virtual QString getVendorString() const = 0;
+    virtual QString getProductIDString() const = 0;
+    virtual QString getProductVersion() const = 0;
+    virtual QString getRawGUIDString() const;
+    virtual QString getRawVendorString() const;
+    virtual QString getRawProductIDString() const;
+    virtual QString getRawProductVersion() const;
+    virtual QString getRawUniqueIDString() const;
     virtual void setCounterUniques(int counter) = 0;
 
     virtual QString getStringIdentifier();

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -67,6 +67,7 @@ class InputDevice : public QObject
     virtual QString getGUIDString() const = 0;
     virtual QString getUniqueIDString() const = 0;
     virtual QString getVendorString() const = 0;
+    virtual QString getSerialString() const = 0;
     virtual QString getProductIDString() const = 0;
     virtual QString getProductVersion() const = 0;
     virtual QString getRawGUIDString() const;

--- a/src/inputdevicecalibration.cpp
+++ b/src/inputdevicecalibration.cpp
@@ -130,6 +130,97 @@ void InputDeviceCalibration::applyCalibrations() const
 }
 
 /**
+ * @brief Reads all calibration values from the given XML stream into the internal calibration data storage
+ * @param QXmlStreamReader instance that will be used to read calibration values.
+ */
+void InputDeviceCalibration::readConfig(QXmlStreamReader *xml)
+{
+    while (xml->isStartElement() && (xml->name() == "calibration"))
+    {
+        QString id = xml->attributes().value("device").toString();
+        if (id.isEmpty())
+            id = m_device->getUniqueIDString();
+        xml->readNextStartElement();
+
+        while (!xml->atEnd() && (!xml->isEndElement() && (xml->name() != "calibration")))
+        {
+            CalibrationData calibration;
+            if ((xml->name() == "stick"))
+            {
+                calibration.type = CALIBRATION_DATA_STICK;
+                calibration.stick.index = xml->attributes().value("index").toString().toInt();
+                calibration.stick.offsetX = xml->attributes().value("offsetx").toString().toDouble();
+                calibration.stick.gainX = xml->attributes().value("gainx").toString().toDouble();
+                calibration.stick.offsetY = xml->attributes().value("offsety").toString().toDouble();
+                calibration.stick.gainY = xml->attributes().value("gainy").toString().toDouble();
+                setCalibration(id, calibration);
+            } else if ((xml->name() == "accelerometer"))
+            {
+                calibration.type = CALIBRATION_DATA_ACCELEROMETER;
+                calibration.accelerometer.orientationX = xml->attributes().value("orientationx").toString().toDouble();
+                calibration.accelerometer.orientationY = xml->attributes().value("orientationy").toString().toDouble();
+                calibration.accelerometer.orientationZ = xml->attributes().value("orientationz").toString().toDouble();
+                setCalibration(id, calibration);
+            } else if ((xml->name() == "gyroscope"))
+            {
+                calibration.type = CALIBRATION_DATA_GYROSCOPE;
+                calibration.gyroscope.offsetX = xml->attributes().value("offsetx").toString().toDouble();
+                calibration.gyroscope.offsetY = xml->attributes().value("offsety").toString().toDouble();
+                calibration.gyroscope.offsetZ = xml->attributes().value("offsetz").toString().toDouble();
+                setCalibration(id, calibration);
+            }
+            xml->skipCurrentElement();
+            xml->readNextStartElement();
+        }
+    }
+}
+
+/**
+ * @brief Writes all stored calibration values from the internal storage into the given XML stream.
+ * @param QXmlStreamWriter instance that will be used to write calibration values.
+ */
+void InputDeviceCalibration::writeConfig(QXmlStreamWriter *xml) const
+{
+    for (auto device = m_data.cbegin(); device != m_data.cend(); ++device)
+    {
+        xml->writeStartElement("calibration");
+        xml->writeAttribute("device", device.key());
+        for (const auto calibration : *device)
+        {
+
+            if (calibration.type == CALIBRATION_DATA_STICK)
+            {
+                const StickCalibrationData &data = calibration.stick;
+                xml->writeStartElement("stick");
+                xml->writeAttribute("index", QString::number(data.index));
+                xml->writeAttribute("offsetx", QString::number(data.offsetX));
+                xml->writeAttribute("gainx", QString::number(data.gainX));
+                xml->writeAttribute("offsety", QString::number(data.offsetY));
+                xml->writeAttribute("gainy", QString::number(data.gainY));
+                xml->writeEndElement();
+            } else if (calibration.type == CALIBRATION_DATA_ACCELEROMETER)
+            {
+                const AccelerometerCalibrationData &data = calibration.accelerometer;
+                xml->writeStartElement("accelerometer");
+                xml->writeAttribute("orientationx", QString::number(data.orientationX));
+                xml->writeAttribute("orientationy", QString::number(data.orientationY));
+                xml->writeAttribute("orientationz", QString::number(data.orientationZ));
+                xml->writeEndElement();
+            } else if (calibration.type == CALIBRATION_DATA_GYROSCOPE)
+            {
+                const GyroscopeCalibrationData &data = calibration.gyroscope;
+                xml->writeStartElement("gyroscope");
+                xml->writeAttribute("offsetx", QString::number(data.offsetX));
+                xml->writeAttribute("offsety", QString::number(data.offsetY));
+                xml->writeAttribute("offsetz", QString::number(data.offsetZ));
+                xml->writeEndElement();
+            }
+        }
+        xml->writeEndElement();
+    }
+}
+
+/**
  * @brief Updated the given CalibrationData structure of the controller with
  *   the given ID in the calibration storage backend.
  * @param[in] id ID of the device to which the calibration data belongs to

--- a/src/inputdevicecalibration.cpp
+++ b/src/inputdevicecalibration.cpp
@@ -21,7 +21,105 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+/**
+ * @brief Returns true if the two CalibrationData structs references the same physical,
+ *   e.g. stick or sensor input on any controller. Otherwise, it returns false.
+ */
+bool CalibrationData::referencesSameInput(const CalibrationData &rhs) const
+{
+    if (type != rhs.type)
+        return false;
+
+    if (type == CALIBRATION_DATA_STICK)
+        return stick.index == rhs.stick.index;
+    else if (type == CALIBRATION_DATA_ACCELEROMETER)
+        return true;
+    else if (type == CALIBRATION_DATA_GYROSCOPE)
+        return true;
+    else
+        return false;
+}
+
 InputDeviceCalibration::InputDeviceCalibration(InputDevice *device)
     : m_device(device)
 {
+}
+
+/**
+ * @brief Updates the stored calibration for the given stick from the parent controller.
+ * @param[in] index Stick index
+ * @param[in] offsetX Offset value for X axis
+ * @param[in] gainX Gain value for X axis
+ * @param[in] offsetY Offset value for Y axis
+ * @param[in] gainY Gain value for Y axis
+ */
+void InputDeviceCalibration::setStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY)
+{
+    CalibrationData calibration;
+    calibration.type = CALIBRATION_DATA_STICK;
+
+    StickCalibrationData &stick = calibration.stick;
+    stick.index = index;
+    stick.offsetX = offsetX;
+    stick.gainX = gainX;
+    stick.offsetY = offsetY;
+    stick.gainY = gainY;
+
+    setCalibration(m_device->getUniqueIDString(), calibration);
+}
+
+/**
+ * @brief Updates the stored calibration for the given accelerometer from the parent controller.
+ * @param[in] orientationX X coordinate of the neutral orientation vector
+ * @param[in] orientationY Y coordinate of the neutral orientation vector
+ * @param[in] orientationZ Z coordinate of the neutral orientation vector
+ */
+void InputDeviceCalibration::setAccelerometerCalibration(double orientationX, double orientationY, double orientationZ)
+{
+    CalibrationData calibration;
+    calibration.type = CALIBRATION_DATA_ACCELEROMETER;
+
+    AccelerometerCalibrationData &accelerometer = calibration.accelerometer;
+    accelerometer.orientationX = orientationX;
+    accelerometer.orientationY = orientationY;
+    accelerometer.orientationZ = orientationZ;
+    setCalibration(m_device->getUniqueIDString(), calibration);
+}
+
+/**
+ * @brief Updates the stored calibration for the given gyroscope from the parent controller.
+ * @param[in] offsetX Offset value for X axis
+ * @param[in] offsetY Offset value for Y axis
+ * @param[in] offsetZ Offset value for Z axis
+ */
+void InputDeviceCalibration::setGyroscopeCalibration(double offsetX, double offsetY, double offsetZ)
+{
+    CalibrationData calibration;
+    calibration.type = CALIBRATION_DATA_GYROSCOPE;
+
+    GyroscopeCalibrationData &gyroscope = calibration.gyroscope;
+    gyroscope.offsetX = offsetX;
+    gyroscope.offsetY = offsetY;
+    gyroscope.offsetZ = offsetZ;
+    setCalibration(m_device->getUniqueIDString(), calibration);
+}
+
+/**
+ * @brief Updated the given CalibrationData structure of the controller with
+ *   the given ID in the calibration storage backend.
+ * @param[in] id ID of the device to which the calibration data belongs to
+ * @param[in] new_calibration The CalibrationData structure to be stored
+ */
+void InputDeviceCalibration::setCalibration(QString id, CalibrationData new_calibration)
+{
+    for (auto &calibration : m_data[id])
+    {
+        if (calibration.referencesSameInput(new_calibration))
+        {
+            calibration = new_calibration;
+            return;
+        }
+    }
+
+    m_data[id].append(new_calibration);
 }

--- a/src/inputdevicecalibration.cpp
+++ b/src/inputdevicecalibration.cpp
@@ -105,6 +105,31 @@ void InputDeviceCalibration::setGyroscopeCalibration(double offsetX, double offs
 }
 
 /**
+ * @brief Applies all applicable stored calibration values to the individual
+ *   input elements of the parent controller
+ */
+void InputDeviceCalibration::applyCalibrations() const
+{
+    QString id = m_device->getUniqueIDString();
+    for (const auto &calibration : m_data[id])
+    {
+        if (calibration.type == CALIBRATION_DATA_STICK)
+        {
+            const StickCalibrationData &data = calibration.stick;
+            m_device->applyStickCalibration(data.index, data.offsetX, data.gainX, data.offsetY, data.gainY);
+        } else if (calibration.type == CALIBRATION_DATA_ACCELEROMETER)
+        {
+            const AccelerometerCalibrationData &data = calibration.accelerometer;
+            m_device->applyAccelerometerCalibration(data.orientationX, data.orientationY, data.orientationZ);
+        } else if (calibration.type == CALIBRATION_DATA_GYROSCOPE)
+        {
+            const GyroscopeCalibrationData &data = calibration.gyroscope;
+            m_device->applyGyroscopeCalibration(data.offsetX, data.offsetY, data.offsetZ);
+        }
+    }
+}
+
+/**
  * @brief Updated the given CalibrationData structure of the controller with
  *   the given ID in the calibration storage backend.
  * @param[in] id ID of the device to which the calibration data belongs to

--- a/src/inputdevicecalibration.cpp
+++ b/src/inputdevicecalibration.cpp
@@ -1,0 +1,27 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "inputdevicecalibration.h"
+#include "inputdevice.h"
+
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+
+InputDeviceCalibration::InputDeviceCalibration(InputDevice *device)
+    : m_device(device)
+{
+}

--- a/src/inputdevicecalibration.h
+++ b/src/inputdevicecalibration.h
@@ -77,6 +77,8 @@ struct CalibrationData
         AccelerometerCalibrationData accelerometer;
         GyroscopeCalibrationData gyroscope;
     };
+
+    bool referencesSameInput(const CalibrationData &rhs) const;
 };
 
 /**
@@ -87,7 +89,12 @@ class InputDeviceCalibration
   public:
     explicit InputDeviceCalibration(InputDevice *device);
 
+    void setStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
+    void setAccelerometerCalibration(double orientationX, double orientationY, double orientationZ);
+    void setGyroscopeCalibration(double offsetX, double offsetY, double offsetZ);
+
   private:
+    void setCalibration(QString id, CalibrationData new_calibration);
     QHash<QString, QList<CalibrationData>> m_data;
 
     InputDevice *m_device;

--- a/src/inputdevicecalibration.h
+++ b/src/inputdevicecalibration.h
@@ -94,6 +94,9 @@ class InputDeviceCalibration
     void setGyroscopeCalibration(double offsetX, double offsetY, double offsetZ);
     void applyCalibrations() const;
 
+    void readConfig(QXmlStreamReader *xml);
+    void writeConfig(QXmlStreamWriter *xml) const;
+
   private:
     void setCalibration(QString id, CalibrationData new_calibration);
     QHash<QString, QList<CalibrationData>> m_data;

--- a/src/inputdevicecalibration.h
+++ b/src/inputdevicecalibration.h
@@ -1,0 +1,94 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QHash>
+
+class InputDevice;
+class QXmlStreamReader;
+class QXmlStreamWriter;
+
+/**
+ * @brief Defines the possible CalibrationData union types
+ */
+enum CalibrationDataType
+{
+    CALIBRATION_DATA_STICK,
+    CALIBRATION_DATA_ACCELEROMETER,
+    CALIBRATION_DATA_GYROSCOPE
+};
+
+/**
+ * @brief The calibration data for a stick
+ */
+struct StickCalibrationData
+{
+    int index;
+    double offsetX;
+    double gainX;
+    double offsetY;
+    double gainY;
+};
+
+/**
+ * @brief The calibration data for an accelerometer
+ */
+struct AccelerometerCalibrationData
+{
+    double orientationX;
+    double orientationY;
+    double orientationZ;
+};
+
+/**
+ * @brief The calibration data for a gyroscope
+ */
+struct GyroscopeCalibrationData
+{
+    double offsetX;
+    double offsetY;
+    double offsetZ;
+};
+
+/**
+ * @brief Stores the calibration data for one physical device, e.g. a stick or gyroscope.
+ */
+struct CalibrationData
+{
+    CalibrationDataType type;
+    union
+    {
+        StickCalibrationData stick;
+        AccelerometerCalibrationData accelerometer;
+        GyroscopeCalibrationData gyroscope;
+    };
+};
+
+/**
+ * @brief Calibration storage backend which can store multiple calibration items for different controllers.
+ */
+class InputDeviceCalibration
+{
+  public:
+    explicit InputDeviceCalibration(InputDevice *device);
+
+  private:
+    QHash<QString, QList<CalibrationData>> m_data;
+
+    InputDevice *m_device;
+};

--- a/src/inputdevicecalibration.h
+++ b/src/inputdevicecalibration.h
@@ -92,6 +92,7 @@ class InputDeviceCalibration
     void setStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);
     void setAccelerometerCalibration(double orientationX, double orientationY, double orientationZ);
     void setGyroscopeCalibration(double offsetX, double offsetY, double offsetZ);
+    void applyCalibrations() const;
 
   private:
     void setCalibration(QString id, CalibrationData new_calibration);

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -44,7 +44,7 @@ Joystick::Joystick(SDL_Joystick *joyhandle, int deviceIndex, AntiMicroSettings *
     INFO() << "Created new Joystick:\n" << getDescription();
 }
 
-QString Joystick::getXmlName() { return GlobalVariables::Joystick::xmlName; }
+QString Joystick::getXmlName() const { return GlobalVariables::Joystick::xmlName; }
 
 QString Joystick::getName() { return QString(tr("Joystick")).append(" ").append(QString::number(getRealJoyNumber())); }
 
@@ -60,7 +60,7 @@ QString Joystick::getSDLName()
     return temp;
 }
 
-QString Joystick::getGUIDString()
+QString Joystick::getGUIDString() const
 {
     QString temp = QString();
 
@@ -73,7 +73,7 @@ QString Joystick::getGUIDString()
     return temp;
 }
 
-QString Joystick::getVendorString()
+QString Joystick::getVendorString() const
 {
     QString temp = QString();
 
@@ -89,7 +89,7 @@ QString Joystick::getVendorString()
     return temp;
 }
 
-QString Joystick::getProductIDString()
+QString Joystick::getProductIDString() const
 {
     QString temp = QString();
 
@@ -105,7 +105,7 @@ QString Joystick::getProductIDString()
     return temp;
 }
 
-QString Joystick::getProductVersion()
+QString Joystick::getProductVersion() const
 {
     QString temp = QString();
 
@@ -121,7 +121,10 @@ QString Joystick::getProductVersion()
     return temp;
 }
 
-QString Joystick::getUniqueIDString() { return (getGUIDString() + getVendorString() + getProductIDString()); }
+QString Joystick::getUniqueIDString() const
+{
+    return (getGUIDString() + getVendorString() + getProductIDString());
+}
 
 void Joystick::closeSDLDevice()
 {

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -105,6 +105,23 @@ QString Joystick::getProductIDString() const
     return temp;
 }
 
+QString Joystick::getSerialString() const
+{
+    QString temp = QString();
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    if (controller != nullptr)
+    {
+        SDL_Joystick *joyhandle = SDL_GameControllerGetJoystick(controller);
+        if (joyhandle != nullptr)
+        {
+            const char *serial = SDL_JoystickGetSerial(joyhandle);
+            temp = QString(serial).remove(QRegExp("[^A-Za-z0-9]"));
+        }
+    }
+#endif
+    return temp;
+}
+
 QString Joystick::getProductVersion() const
 {
     QString temp = QString();
@@ -123,7 +140,7 @@ QString Joystick::getProductVersion() const
 
 QString Joystick::getUniqueIDString() const
 {
-    return (getGUIDString() + getVendorString() + getProductIDString());
+    return (getGUIDString() + getVendorString() + getProductIDString()) + getSerialString();
 }
 
 void Joystick::closeSDLDevice()

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -34,11 +34,11 @@ class Joystick : public InputDevice
 
     virtual QString getName() override;
     virtual QString getSDLName() override;
-    virtual QString getGUIDString() override; // GUID available on SDL 2.
-    virtual QString getUniqueIDString() override;
-    virtual QString getVendorString() override;
-    virtual QString getProductIDString() override;
-    virtual QString getProductVersion() override;
+    virtual QString getGUIDString() const override; // GUID available on SDL 2.
+    virtual QString getUniqueIDString() const override;
+    virtual QString getVendorString() const override;
+    virtual QString getProductIDString() const override;
+    virtual QString getProductVersion() const override;
 
     virtual void closeSDLDevice() override;
     virtual SDL_JoystickID getSDLJoystickID() override;
@@ -52,7 +52,7 @@ class Joystick : public InputDevice
     void setCounterUniques(int counter) override;
 
     SDL_Joystick *getJoyhandle() const;
-    virtual QString getXmlName() override;
+    virtual QString getXmlName() const override;
 
   private:
     SDL_Joystick *m_joyhandle;

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -38,6 +38,7 @@ class Joystick : public InputDevice
     virtual QString getUniqueIDString() const override;
     virtual QString getVendorString() const override;
     virtual QString getProductIDString() const override;
+    virtual QString getSerialString() const override;
     virtual QString getProductVersion() const override;
 
     virtual void closeSDLDevice() override;


### PR DESCRIPTION
When you have a game console with multiple controllers and grab a random controller
every time you use it with AntimicroX, there is a good chance that the calibration
values are now incorrect since it is another physical device.

Thus, implement an internal calibration storage backend which stores calibration values for multiple controllers
and apply the correct calibration value for the current controller on load.

To distinguish multiple identical controllers types, e.g. Nintendo Switch controllers, while they are not connected simultaneously,
append the device serial number to the unique ID string.