### PR TITLE
Deep-copy JoyButtonSlot's mix slots

### DIFF
--- a/src/joybuttonslot.cpp
+++ b/src/joybuttonslot.cpp
@@ -149,13 +149,13 @@ void JoyButtonSlot::setSlotCode(int code, int alias)
     }
 }
 
-int JoyButtonSlot::getSlotCodeAlias() { return qkeyaliasCode; }
+int JoyButtonSlot::getSlotCodeAlias() const { return qkeyaliasCode; }
 
-int JoyButtonSlot::getSlotCode() { return deviceCode; }
+int JoyButtonSlot::getSlotCode() const { return deviceCode; }
 
 void JoyButtonSlot::setSlotMode(JoySlotInputAction selectedMode) { m_mode = selectedMode; }
 
-JoyButtonSlot::JoySlotInputAction JoyButtonSlot::getSlotMode() { return m_mode; }
+JoyButtonSlot::JoySlotInputAction JoyButtonSlot::getSlotMode() const { return m_mode; }
 
 QString JoyButtonSlot::movementString()
 {
@@ -402,7 +402,7 @@ QString JoyButtonSlot::getSlotString()
 
 void JoyButtonSlot::setPreviousDistance(double distance) { previousDistance = distance; }
 
-double JoyButtonSlot::getPreviousDistance() { return previousDistance; }
+double JoyButtonSlot::getPreviousDistance() const { return previousDistance; }
 
 double JoyButtonSlot::getDistance() const { return m_distance; }
 
@@ -418,7 +418,7 @@ bool JoyButtonSlot::isModifierKey()
     return modifier;
 }
 
-bool JoyButtonSlot::isEasingActive() { return easingActive; }
+bool JoyButtonSlot::isEasingActive() const { return easingActive; }
 
 void JoyButtonSlot::setEasingStatus(bool isActive) { easingActive = isActive; }
 
@@ -426,7 +426,7 @@ QElapsedTimer *JoyButtonSlot::getEasingTime() { return &easingTime; }
 
 void JoyButtonSlot::setTextData(QString textData) { m_textData = textData; }
 
-QString JoyButtonSlot::getTextData()
+QString JoyButtonSlot::getTextData() const
 {
     if (m_textData.isNull() || m_textData.isEmpty())
         return "";
@@ -435,7 +435,7 @@ QString JoyButtonSlot::getTextData()
 
 void JoyButtonSlot::setExtraData(QVariant data) { this->extraData = data; }
 
-QVariant JoyButtonSlot::getExtraData() { return extraData; }
+QVariant JoyButtonSlot::getExtraData() const { return extraData; }
 
 void JoyButtonSlot::secureMixSlotsInit()
 {

--- a/src/joybuttonslot.cpp
+++ b/src/joybuttonslot.cpp
@@ -77,35 +77,9 @@ JoyButtonSlot::JoyButtonSlot(int code, int alias, JoySlotInputAction mode, QObje
 JoyButtonSlot::JoyButtonSlot(JoyButtonSlot *slot, QObject *parent)
     : QObject(parent)
     , extraData()
+    , mix_slots(nullptr)
 {
-    this->deviceCode = slot->getSlotCode();
-    this->m_mode = slot->getSlotMode();
-    this->qkeyaliasCode = slot->getSlotCodeAlias();
-    this->m_distance = slot->getDistance();
-    this->previousDistance = slot->getPreviousDistance();
-    this->easingActive = slot->isEasingActive();
-    easingTime = QElapsedTimer();
-    if (slot->getEasingTime()->isValid())
-        easingTime.start();
-    this->extraData = slot->getExtraData();
-
-    /*
-     * if (slot->getMixSlots() != nullptr)
-    {
-        secureMixSlotsInit();
-
-        for(auto minislot : *slot->getMixSlots())
-        {
-            this->mix_slots->append(new JoyButtonSlot(minislot->getSlotCode(), minislot->getSlotCodeAlias(),
-    minislot->getSlotMode()));
-        }
-    }*/
-
-    if (slot->getMixSlots() != nullptr)
-        this->mix_slots = slot->getMixSlots();
-
-    if (!slot->getTextData().isNull() && (slot->getTextData() != ""))
-        this->m_textData = slot->getTextData();
+    copyAssignments(*slot);
 }
 
 JoyButtonSlot::JoyButtonSlot(QString text, JoySlotInputAction mode, QObject *parent)
@@ -437,6 +411,39 @@ void JoyButtonSlot::setExtraData(QVariant data) { this->extraData = data; }
 
 QVariant JoyButtonSlot::getExtraData() const { return extraData; }
 
+/**
+ * @brief Deep-copies member variables from another JoyButtonSlot object
+ *   into this object.
+ * @param[in] slot Slot from which data gets copied
+ */
+void JoyButtonSlot::copyAssignments(const JoyButtonSlot &slot)
+{
+    deviceCode = slot.deviceCode;
+    qkeyaliasCode = slot.qkeyaliasCode;
+    m_mode = slot.m_mode;
+
+    if (slot.mix_slots != nullptr)
+    {
+        mix_slots = new QList<JoyButtonSlot *>();
+        for (const auto minislot : *slot.mix_slots)
+            mix_slots->append(
+                new JoyButtonSlot(minislot->getSlotCode(), minislot->getSlotCodeAlias(), minislot->getSlotMode()));
+    }
+
+    m_distance = slot.m_distance;
+    previousDistance = slot.previousDistance;
+
+    easingTime = QElapsedTimer();
+    if (slot.easingTime.isValid())
+        easingTime.start();
+    easingActive = slot.easingActive;
+
+    if (!slot.getTextData().isNull() && (slot.getTextData() != ""))
+        m_textData = slot.getTextData();
+
+    extraData = slot.extraData;
+}
+
 void JoyButtonSlot::secureMixSlotsInit()
 {
     if (mix_slots == nullptr)
@@ -509,22 +516,6 @@ bool JoyButtonSlot::isValidSlot()
 
 JoyButtonSlot &JoyButtonSlot::operator=(JoyButtonSlot *slot)
 {
-    this->deviceCode = slot->getSlotCode();
-    this->m_mode = slot->getSlotMode();
-    this->qkeyaliasCode = slot->getSlotCodeAlias();
-    this->m_distance = slot->getDistance();
-    this->previousDistance = slot->getPreviousDistance();
-    this->easingActive = slot->isEasingActive();
-    easingTime = QElapsedTimer();
-    if (slot->getEasingTime()->isValid())
-        easingTime.start();
-    this->extraData = slot->getExtraData();
-
-    if (slot->getMixSlots() != nullptr)
-        this->mix_slots = slot->getMixSlots();
-
-    if (!slot->getTextData().isNull() ^ (slot->getTextData() != ""))
-        this->m_textData = slot->getTextData();
-
+    copyAssignments(*slot);
     return *this;
 }

--- a/src/joybuttonslot.h
+++ b/src/joybuttonslot.h
@@ -134,6 +134,7 @@ class JoyButtonSlot : public QObject
     JoyButtonSlot &operator=(JoyButtonSlot *slot);
 
   private:
+    void copyAssignments(const JoyButtonSlot &rhs);
     void secureMixSlotsInit();
 
     int deviceCode;

--- a/src/joybuttonslot.h
+++ b/src/joybuttonslot.h
@@ -88,9 +88,9 @@ class JoyButtonSlot : public QObject
     ~JoyButtonSlot();
 
     void setSlotCode(int code);
-    int getSlotCode();
+    int getSlotCode() const;
     void setSlotMode(JoySlotInputAction selectedMode);
-    JoySlotInputAction getSlotMode();
+    JoySlotInputAction getSlotMode() const;
     QString movementString();
     void setMouseSpeed(int value);
     void setDistance(double distance);
@@ -100,21 +100,21 @@ class JoyButtonSlot : public QObject
     QString getXmlName();
     QString getSlotString();
     void setSlotCode(int code, int alias);
-    int getSlotCodeAlias();
+    int getSlotCodeAlias() const;
     void setPreviousDistance(double distance);
-    double getPreviousDistance();
+    double getPreviousDistance() const;
     double getDistance() const;
     bool isModifierKey();
 
-    bool isEasingActive();
+    bool isEasingActive() const;
     void setEasingStatus(bool isActive);
     QElapsedTimer *getEasingTime();
 
     void setTextData(QString textData);
-    QString getTextData();
+    QString getTextData() const;
 
     void setExtraData(QVariant data);
-    QVariant getExtraData();
+    QVariant getExtraData() const;
 
     void setMixSlots(QList<JoyButtonSlot *> *slots);
     QList<JoyButtonSlot *> *getMixSlots();


### PR DESCRIPTION
When button assignments are copied from one set to another, the shallow
copy of the mix slots causes a crash on exit due to the double free.

Use the already existing but commented out deep-copy code and extract a
method which is used for the copy-constructor and the assignment
operator.

Make some getters const to be able to use a const reference in the new copy function.

Fixes #454