### PR TITLE
Add device serial to unique ID string

### DIFF
--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -77,6 +77,19 @@ QString GameController::getVendorString() const { return getRawVendorString(); }
 
 QString GameController::getProductIDString() const { return getRawProductIDString(); }
 
+QString GameController::getSerialString() const
+{
+    QString temp = QString();
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    if (controller != nullptr)
+    {
+        const char *serial = SDL_GameControllerGetSerial(controller);
+        temp = QString(serial).remove(QRegExp("[^A-Za-z0-9]"));
+    }
+#endif
+    return temp;
+}
+
 QString GameController::getUniqueIDString() const { return getRawUniqueIDString(); }
 
 QString GameController::getProductVersion() const { return getRawProductVersion(); }
@@ -151,7 +164,7 @@ QString GameController::getRawProductVersion() const
 
 QString GameController::getRawUniqueIDString() const
 {
-    return (getRawGUIDString() + getRawVendorString() + getRawProductIDString());
+    return (getRawGUIDString() + getRawVendorString() + getRawProductIDString() + getSerialString());
 }
 
 void GameController::closeSDLDevice()

--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -69,19 +69,19 @@ QString GameController::getSDLName()
     return temp;
 }
 
-QString GameController::getXmlName() { return GlobalVariables::GameController::xmlName; }
+QString GameController::getXmlName() const { return GlobalVariables::GameController::xmlName; }
 
-QString GameController::getGUIDString() { return getRawGUIDString(); }
+QString GameController::getGUIDString() const { return getRawGUIDString(); }
 
-QString GameController::getVendorString() { return getRawVendorString(); }
+QString GameController::getVendorString() const { return getRawVendorString(); }
 
-QString GameController::getProductIDString() { return getRawProductIDString(); }
+QString GameController::getProductIDString() const { return getRawProductIDString(); }
 
-QString GameController::getUniqueIDString() { return getRawUniqueIDString(); }
+QString GameController::getUniqueIDString() const { return getRawUniqueIDString(); }
 
-QString GameController::getProductVersion() { return getRawProductVersion(); }
+QString GameController::getProductVersion() const { return getRawProductVersion(); }
 
-QString GameController::getRawGUIDString()
+QString GameController::getRawGUIDString() const
 {
     QString temp = QString();
 
@@ -101,7 +101,7 @@ QString GameController::getRawGUIDString()
     return temp;
 }
 
-QString GameController::getRawVendorString()
+QString GameController::getRawVendorString() const
 {
     QString temp = QString();
 
@@ -117,7 +117,7 @@ QString GameController::getRawVendorString()
     return temp;
 }
 
-QString GameController::getRawProductIDString()
+QString GameController::getRawProductIDString() const
 {
     QString temp = QString();
 
@@ -133,7 +133,7 @@ QString GameController::getRawProductIDString()
     return temp;
 }
 
-QString GameController::getRawProductVersion()
+QString GameController::getRawProductVersion() const
 {
     QString temp = QString();
 
@@ -149,7 +149,7 @@ QString GameController::getRawProductVersion()
     return temp;
 }
 
-QString GameController::getRawUniqueIDString()
+QString GameController::getRawUniqueIDString() const
 {
     return (getRawGUIDString() + getRawVendorString() + getRawProductIDString());
 }

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -44,6 +44,7 @@ class GameController : public InputDevice
     virtual QString getGUIDString() const override;
     virtual QString getVendorString() const override;
     virtual QString getProductIDString() const override;
+    virtual QString getSerialString() const override;
     virtual QString getUniqueIDString() const override;
     virtual QString getRawGUIDString() const override;
     virtual QString getProductVersion() const override;

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -38,19 +38,19 @@ class GameController : public InputDevice
 
     virtual QString getName() override;
     virtual QString getSDLName() override;
-    virtual QString getXmlName() override;
+    virtual QString getXmlName() const override;
 
     // GUID available on SDL 2.
-    virtual QString getGUIDString() override;
-    virtual QString getVendorString() override;
-    virtual QString getProductIDString() override;
-    virtual QString getUniqueIDString() override;
-    virtual QString getProductVersion() override;
-    virtual QString getRawGUIDString() override;
-    virtual QString getRawUniqueIDString() override;
-    virtual QString getRawVendorString() override;
-    virtual QString getRawProductIDString() override;
-    virtual QString getRawProductVersion() override;
+    virtual QString getGUIDString() const override;
+    virtual QString getVendorString() const override;
+    virtual QString getProductIDString() const override;
+    virtual QString getUniqueIDString() const override;
+    virtual QString getRawGUIDString() const override;
+    virtual QString getProductVersion() const override;
+    virtual QString getRawUniqueIDString() const override;
+    virtual QString getRawVendorString() const override;
+    virtual QString getRawProductIDString() const override;
+    virtual QString getRawProductVersion() const override;
 
     virtual bool isGameController() override;
     virtual void closeSDLDevice() override;

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1217,6 +1217,7 @@ QString InputDevice::getDescription()
                         QObject::tr("GUID:             %1").arg(getGUIDString()) + "\n  " +
                         QObject::tr("VendorID:         %1").arg(getVendorString()) + "\n  " +
                         QObject::tr("ProductID:        %1").arg(getProductIDString()) + "\n  " +
+                        QObject::tr("Serial:           %1").arg(getSerialString()) + "\n  " +
                         QObject::tr("Product Version:  %1").arg(getProductVersion()) + "\n  " +
                         QObject::tr("Name:             %1").arg(getSDLName()) + "\n";
     QString gameControllerStatus = isGameController() ? QObject::tr("Yes") : QObject::tr("No");

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1545,15 +1545,15 @@ bool InputDevice::isRelevantUniqueID(QString tempUniqueID)
     return result;
 }
 
-QString InputDevice::getRawGUIDString() { return getGUIDString(); }
+QString InputDevice::getRawGUIDString() const { return getGUIDString(); }
 
-QString InputDevice::getRawVendorString() { return getVendorString(); }
+QString InputDevice::getRawVendorString() const { return getVendorString(); }
 
-QString InputDevice::getRawProductIDString() { return getProductIDString(); }
+QString InputDevice::getRawProductIDString() const { return getProductIDString(); }
 
-QString InputDevice::getRawProductVersion() { return getProductVersion(); }
+QString InputDevice::getRawProductVersion() const { return getProductVersion(); }
 
-QString InputDevice::getRawUniqueIDString() { return getUniqueIDString(); }
+QString InputDevice::getRawUniqueIDString() const { return getUniqueIDString(); }
 
 void InputDevice::haltServices() { emit requestWait(); }
 

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -52,22 +52,22 @@ class InputDevice : public QObject
     bool isActive();
     int getButtonDownCount();
 
-    virtual QString getXmlName() = 0;
+    virtual QString getXmlName() const = 0;
     virtual QString getName() = 0;
     virtual QString getSDLName() = 0;
     virtual QString getDescription();
 
     // GUID only available on SDL 2.
-    virtual QString getGUIDString() = 0;
-    virtual QString getUniqueIDString() = 0;
-    virtual QString getVendorString() = 0;
-    virtual QString getProductIDString() = 0;
-    virtual QString getProductVersion() = 0;
-    virtual QString getRawGUIDString();
-    virtual QString getRawVendorString();
-    virtual QString getRawProductIDString();
-    virtual QString getRawProductVersion();
-    virtual QString getRawUniqueIDString();
+    virtual QString getGUIDString() const = 0;
+    virtual QString getUniqueIDString() const = 0;
+    virtual QString getVendorString() const = 0;
+    virtual QString getProductIDString() const = 0;
+    virtual QString getProductVersion() const = 0;
+    virtual QString getRawGUIDString() const;
+    virtual QString getRawVendorString() const;
+    virtual QString getRawProductIDString() const;
+    virtual QString getRawProductVersion() const;
+    virtual QString getRawUniqueIDString() const;
     virtual void setCounterUniques(int counter) = 0;
 
     virtual QString getStringIdentifier();

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -61,6 +61,7 @@ class InputDevice : public QObject
     virtual QString getGUIDString() const = 0;
     virtual QString getUniqueIDString() const = 0;
     virtual QString getVendorString() const = 0;
+    virtual QString getSerialString() const = 0;
     virtual QString getProductIDString() const = 0;
     virtual QString getProductVersion() const = 0;
     virtual QString getRawGUIDString() const;

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -44,7 +44,7 @@ Joystick::Joystick(SDL_Joystick *joyhandle, int deviceIndex, AntiMicroSettings *
     INFO() << "Created new Joystick:\n" << getDescription();
 }
 
-QString Joystick::getXmlName() { return GlobalVariables::Joystick::xmlName; }
+QString Joystick::getXmlName() const { return GlobalVariables::Joystick::xmlName; }
 
 QString Joystick::getName() { return QString(tr("Joystick")).append(" ").append(QString::number(getRealJoyNumber())); }
 
@@ -60,7 +60,7 @@ QString Joystick::getSDLName()
     return temp;
 }
 
-QString Joystick::getGUIDString()
+QString Joystick::getGUIDString() const
 {
     QString temp = QString();
 
@@ -73,7 +73,7 @@ QString Joystick::getGUIDString()
     return temp;
 }
 
-QString Joystick::getVendorString()
+QString Joystick::getVendorString() const
 {
     QString temp = QString();
 
@@ -89,7 +89,7 @@ QString Joystick::getVendorString()
     return temp;
 }
 
-QString Joystick::getProductIDString()
+QString Joystick::getProductIDString() const
 {
     QString temp = QString();
 
@@ -105,7 +105,7 @@ QString Joystick::getProductIDString()
     return temp;
 }
 
-QString Joystick::getProductVersion()
+QString Joystick::getProductVersion() const
 {
     QString temp = QString();
 
@@ -121,7 +121,10 @@ QString Joystick::getProductVersion()
     return temp;
 }
 
-QString Joystick::getUniqueIDString() { return (getGUIDString() + getVendorString() + getProductIDString()); }
+QString Joystick::getUniqueIDString() const
+{
+    return (getGUIDString() + getVendorString() + getProductIDString());
+}
 
 void Joystick::closeSDLDevice()
 {

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -105,6 +105,23 @@ QString Joystick::getProductIDString() const
     return temp;
 }
 
+QString Joystick::getSerialString() const
+{
+    QString temp = QString();
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    if (controller != nullptr)
+    {
+        SDL_Joystick *joyhandle = SDL_GameControllerGetJoystick(controller);
+        if (joyhandle != nullptr)
+        {
+            const char *serial = SDL_JoystickGetSerial(joyhandle);
+            temp = QString(serial).remove(QRegExp("[^A-Za-z0-9]"));
+        }
+    }
+#endif
+    return temp;
+}
+
 QString Joystick::getProductVersion() const
 {
     QString temp = QString();
@@ -123,7 +140,7 @@ QString Joystick::getProductVersion() const
 
 QString Joystick::getUniqueIDString() const
 {
-    return (getGUIDString() + getVendorString() + getProductIDString());
+    return (getGUIDString() + getVendorString() + getProductIDString()) + getSerialString();
 }
 
 void Joystick::closeSDLDevice()

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -34,11 +34,11 @@ class Joystick : public InputDevice
 
     virtual QString getName() override;
     virtual QString getSDLName() override;
-    virtual QString getGUIDString() override; // GUID available on SDL 2.
-    virtual QString getUniqueIDString() override;
-    virtual QString getVendorString() override;
-    virtual QString getProductIDString() override;
-    virtual QString getProductVersion() override;
+    virtual QString getGUIDString() const override; // GUID available on SDL 2.
+    virtual QString getUniqueIDString() const override;
+    virtual QString getVendorString() const override;
+    virtual QString getProductIDString() const override;
+    virtual QString getProductVersion() const override;
 
     virtual void closeSDLDevice() override;
     virtual SDL_JoystickID getSDLJoystickID() override;
@@ -49,7 +49,7 @@ class Joystick : public InputDevice
     void setCounterUniques(int counter) override;
 
     SDL_Joystick *getJoyhandle() const;
-    virtual QString getXmlName() override;
+    virtual QString getXmlName() const override;
 
   private:
     SDL_Joystick *m_joyhandle;

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -38,6 +38,7 @@ class Joystick : public InputDevice
     virtual QString getUniqueIDString() const override;
     virtual QString getVendorString() const override;
     virtual QString getProductIDString() const override;
+    virtual QString getSerialString() const override;
     virtual QString getProductVersion() const override;
 
     virtual void closeSDLDevice() override;


### PR DESCRIPTION
When connecting different controllers, e.g. Nintendo Switch controllers,
one after another, they get the identical unique ID strings which can cause problems.

As solution, read the device serial number via SDL if supported and append it to the unique ID string.

Should fix #451