### PR TITLE
fix: Broken auto profile saving for Windows

### DIFF
--- a/src/gui/mainsettingsdialog.cpp
+++ b/src/gui/mainsettingsdialog.cpp
@@ -557,7 +557,8 @@ void MainSettingsDialog::saveNewSettings()
     {
         saveAutoProfileSettings();
     }
-
+#else
+    saveAutoProfileSettings();
 #endif
 
     settings->getLock()->lock();


### PR DESCRIPTION
This bug was created during restoration of Windows support

Closes: https://github.com/AntiMicroX/antimicrox/issues/421
