### PR TITLE
Add support for DualSense trigger haptic feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ set(antimicrox_SOURCES
         src/gui/setaxisthrottledialog.cpp
         src/gui/setnamesdialog.cpp
         src/gui/slotitemlistwidget.cpp
+        src/haptictriggerps5.cpp
         src/inputdaemon.cpp
         src/inputdevice.cpp
         src/inputdevicebitarraystatus.cpp
@@ -295,6 +296,8 @@ set(antimicrox_HEADERS
         src/gui/setaxisthrottledialog.h
         src/gui/setnamesdialog.h
         src/gui/slotitemlistwidget.h
+        src/haptictriggerps5.h
+        src/haptictriggermodeps5.h
         src/inputdaemon.h
         src/inputdevice.h
         src/inputdevicebitarraystatus.h

--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -42,6 +42,7 @@ GameController::GameController(SDL_GameController *controller, int deviceIndex, 
 
     SDL_Joystick *joyhandle = SDL_GameControllerGetJoystick(controller);
     joystickID = SDL_JoystickInstanceID(joyhandle);
+    m_type = SDL_GameControllerGetType(controller);
 
     for (int i = 0; i < GlobalVariables::InputDevice::NUMBER_JOYSETS; i++)
     {
@@ -402,3 +403,8 @@ QHash<int, int> const &GameController::getAxisvalues() { return axisvalues; }
 QHash<int, int> const &GameController::getDpadvalues() { return dpadvalues; }
 
 SDL_GameController *GameController::getController() const { return controller; }
+
+/**
+ * @brief Returns the current controller model.
+ */
+SDL_GameControllerType GameController::getControllerType() const { return m_type; }

--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -42,7 +42,11 @@ GameController::GameController(SDL_GameController *controller, int deviceIndex, 
 
     SDL_Joystick *joyhandle = SDL_GameControllerGetJoystick(controller);
     joystickID = SDL_JoystickInstanceID(joyhandle);
-    m_type = SDL_GameControllerGetType(controller);
+#if SDL_VERSION_ATLEAST(2, 0, 16)
+    m_controller_type = SDL_GameControllerGetType(controller);
+#else
+    m_controller_type = SDL_CONTROLLER_TYPE_UNKNOWN;
+#endif
 
     for (int i = 0; i < GlobalVariables::InputDevice::NUMBER_JOYSETS; i++)
     {
@@ -407,4 +411,4 @@ SDL_GameController *GameController::getController() const { return controller; }
 /**
  * @brief Returns the current controller model.
  */
-SDL_GameControllerType GameController::getControllerType() const { return m_type; }
+SDL_GameControllerType GameController::getControllerType() const { return m_controller_type; }

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -81,6 +81,7 @@ class GameController : public InputDevice
     QHash<int, int> const &getDpadvalues();
 
     SDL_GameController *getController() const;
+    virtual SDL_GameControllerType getControllerType() const override;
 
     void fillContainers(QHash<int, SDL_GameControllerButton> &buttons, QHash<int, SDL_GameControllerAxis> &axes,
                         QList<SDL_GameControllerButtonBind> &hatButtons);
@@ -98,6 +99,7 @@ class GameController : public InputDevice
 
     SDL_JoystickID joystickID;
     SDL_GameController *controller;
+    SDL_GameControllerType m_type;
 };
 
 #endif // GAMECONTROLLER_H

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -99,7 +99,7 @@ class GameController : public InputDevice
 
     SDL_JoystickID joystickID;
     SDL_GameController *controller;
-    SDL_GameControllerType m_type;
+    SDL_GameControllerType m_controller_type;
 };
 
 #endif // GAMECONTROLLER_H

--- a/src/gamecontroller/gamecontrollerset.cpp
+++ b/src/gamecontroller/gamecontrollerset.cpp
@@ -21,6 +21,7 @@
 #include "gamecontroller.h"
 #include "gamecontrollerdpad.h"
 #include "gamecontrollertrigger.h"
+#include "haptictriggerps5.h"
 #include "inputdevice.h"
 #include "joycontrolstick.h"
 #include "joysensor.h"

--- a/src/gamecontroller/gamecontrollerset.cpp
+++ b/src/gamecontroller/gamecontrollerset.cpp
@@ -36,9 +36,28 @@ GameControllerSet::GameControllerSet(InputDevice *device, int index, QObject *pa
     : SetJoystick(device, index, false, parent)
 {
     resetSticks();
+    applyHapticTrigger();
 }
 
 void GameControllerSet::reset() { resetSticks(); }
+
+/**
+ * @brief Applies haptic feedback to the triggers of the controller.
+ *
+ * This fetches the current haptic feedback effects from all triggers of the
+ * controller, builds a low level message and sends the message to the controller.
+ */
+void GameControllerSet::applyHapticTrigger()
+{
+    GameController *controller = qobject_cast<GameController *>(getInputDevice());
+    HapticTriggerPs5 *left_effect = getJoyAxis(SDL_CONTROLLER_AXIS_TRIGGERLEFT)->getHapticTrigger();
+    HapticTriggerPs5 *right_effect = getJoyAxis(SDL_CONTROLLER_AXIS_TRIGGERRIGHT)->getHapticTrigger();
+
+    if (left_effect == nullptr || right_effect == nullptr)
+        return;
+
+    HapticTriggerPs5::send(controller->getController(), *left_effect, *right_effect);
+}
 
 void GameControllerSet::resetSticks()
 {
@@ -223,6 +242,7 @@ void GameControllerSet::refreshAxes()
             GameControllerTrigger *trigger = new GameControllerTrigger(i, getIndex(), this, this);
             getAxes()->insert(i, trigger);
             enableAxisConnections(trigger);
+            connect(trigger, &JoyAxis::hapticTriggerChanged, this, &GameControllerSet::applyHapticTrigger);
         } else
         {
             JoyAxis *axis = new JoyAxis(i, getIndex(), this, this);

--- a/src/gamecontroller/gamecontrollerset.h
+++ b/src/gamecontroller/gamecontrollerset.h
@@ -45,6 +45,7 @@ class GameControllerSet : public SetJoystick
 
   public slots:
     virtual void reset();
+    void applyHapticTrigger();
 
   private:
     void getElemFromXml(QString elemName, QXmlStreamReader *xml);

--- a/src/gamecontroller/gamecontrollertrigger.cpp
+++ b/src/gamecontroller/gamecontrollertrigger.cpp
@@ -133,3 +133,27 @@ JoyAxis::ThrottleTypes GameControllerTrigger::getDefaultThrottle()
 {
     return static_cast<ThrottleTypes>(this->DEFAULTTHROTTLE);
 }
+
+/**
+ * @brief Checks if the trigger supports haptic feedback.
+ * @returns True if the trigger supports haptic feedback, false otherwise.
+ */
+bool GameControllerTrigger::hasHapticTrigger() const { return m_haptic_trigger != 0; }
+
+/**
+ * @returns Pointer to HapticTriggerPs5 object of this trigger.
+ */
+HapticTriggerPs5 *GameControllerTrigger::getHapticTrigger() const { return m_haptic_trigger; }
+
+/**
+ * @brief Changes the haptic feedback effect mode.
+ * @param[in] mode New haptic feedback effect mode.
+ */
+void GameControllerTrigger::setHapticTriggerMode(HapticTriggerModePs5 mode)
+{
+    if (m_haptic_trigger == 0)
+        return;
+
+    if (m_haptic_trigger->set_effect_mode(mode))
+        emit hapticTriggerChanged();
+}

--- a/src/gamecontroller/gamecontrollertrigger.cpp
+++ b/src/gamecontroller/gamecontrollertrigger.cpp
@@ -46,10 +46,10 @@ GameControllerTrigger::GameControllerTrigger(int index, int originset, SetJoysti
     paxisbutton = new GameControllerTriggerButton(this, 1, originset, parentSet, this);
     reset(index);
 
+#if SDL_VERSION_ATLEAST(2, 0, 16)
     if (parentSet->getInputDevice()->getControllerType() == SDL_GameControllerType::SDL_CONTROLLER_TYPE_PS5)
-    {
         m_haptic_trigger = new HapticTriggerPs5(this);
-    }
+#endif
 }
 
 void GameControllerTrigger::reset(int index)

--- a/src/gamecontroller/gamecontrollertrigger.cpp
+++ b/src/gamecontroller/gamecontrollertrigger.cpp
@@ -141,9 +141,38 @@ JoyAxis::ThrottleTypes GameControllerTrigger::getDefaultThrottle()
 bool GameControllerTrigger::hasHapticTrigger() const { return m_haptic_trigger != 0; }
 
 /**
+ * @brief Recalculates haptic trigger effect positions, e.g. after dead zone change,
+ *   and returns the current HapticTriggerPs5 object.
  * @returns Pointer to HapticTriggerPs5 object of this trigger.
  */
-HapticTriggerPs5 *GameControllerTrigger::getHapticTrigger() const { return m_haptic_trigger; }
+HapticTriggerPs5 *GameControllerTrigger::getHapticTrigger() const
+{
+    if (m_haptic_trigger == nullptr)
+        return nullptr;
+
+    int start, end;
+    switch (m_haptic_trigger->get_mode())
+    {
+    case HAPTIC_TRIGGER_NONE:
+        m_haptic_trigger->set_effect(0, 0, 0);
+        break;
+    case HAPTIC_TRIGGER_CLICK:
+        start = double(deadZone) * 192 / GlobalVariables::JoyAxis::AXISMAX;
+        end = start + 65;
+        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::STRENGTH, start, end);
+        break;
+    case HAPTIC_TRIGGER_RIGID:
+        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::STRENGTH, 0,
+                                     GlobalVariables::HapticTriggerPs5::RANGE);
+        break;
+    case HAPTIC_TRIGGER_VIBRATION:
+        start = double(deadZone) * 192 / GlobalVariables::JoyAxis::AXISMAX;
+        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::VIBRATIONSTRENGTH, start,
+                                     GlobalVariables::HapticTriggerPs5::RANGE, GlobalVariables::HapticTriggerPs5::FREQUENCY);
+        break;
+    }
+    return m_haptic_trigger;
+}
 
 /**
  * @brief Changes the haptic feedback effect mode.

--- a/src/gamecontroller/gamecontrollertrigger.cpp
+++ b/src/gamecontroller/gamecontrollertrigger.cpp
@@ -22,6 +22,9 @@
 
 #include "gamecontrollertriggerbutton.h"
 #include "globalvariables.h"
+#include "haptictriggerps5.h"
+#include "inputdevice.h"
+#include "setjoystick.h"
 #include "xml/joyaxisxml.h"
 
 #include <SDL2/SDL_gamecontroller.h>
@@ -35,12 +38,18 @@ const GameControllerTrigger::ThrottleTypes GameControllerTrigger::DEFAULTTHROTTL
 
 GameControllerTrigger::GameControllerTrigger(int index, int originset, SetJoystick *parentSet, QObject *parent)
     : JoyAxis(index, originset, parentSet, parent)
+    , m_haptic_trigger(0)
 {
     naxisbutton->deleteLater();
     naxisbutton = new GameControllerTriggerButton(this, 0, originset, parentSet, this);
     paxisbutton->deleteLater();
     paxisbutton = new GameControllerTriggerButton(this, 1, originset, parentSet, this);
     reset(index);
+
+    if (parentSet->getInputDevice()->getControllerType() == SDL_GameControllerType::SDL_CONTROLLER_TYPE_PS5)
+    {
+        m_haptic_trigger = new HapticTriggerPs5(this);
+    }
 }
 
 void GameControllerTrigger::reset(int index)

--- a/src/gamecontroller/gamecontrollertrigger.h
+++ b/src/gamecontroller/gamecontrollertrigger.h
@@ -42,6 +42,10 @@ class GameControllerTrigger : public JoyAxis
 
     static const ThrottleTypes DEFAULTTHROTTLE;
 
+    virtual bool hasHapticTrigger() const override;
+    virtual HapticTriggerPs5 *getHapticTrigger() const override;
+    virtual void setHapticTriggerMode(HapticTriggerModePs5 mode) override;
+
   public slots:
     virtual void reset();
     virtual void reset(int index);

--- a/src/gamecontroller/gamecontrollertrigger.h
+++ b/src/gamecontroller/gamecontrollertrigger.h
@@ -21,6 +21,7 @@
 
 #include "joyaxis.h"
 
+class HapticTriggerPs5;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 class SetJoystick;
@@ -47,6 +48,8 @@ class GameControllerTrigger : public JoyAxis
 
   protected:
     void correctJoystickThrottle();
+
+    HapticTriggerPs5 *m_haptic_trigger;
 };
 
 #endif // GAMECONTROLLERTRIGGER_H

--- a/src/globalvariables.cpp
+++ b/src/globalvariables.cpp
@@ -117,6 +117,11 @@ const float GlobalVariables::JoyAxis::JOYSPEED = 20.0;
 
 const QString GlobalVariables::JoyAxis::xmlName = "axis";
 
+const int GlobalVariables::HapticTriggerPs5::STRENGTH = 4;
+const int GlobalVariables::HapticTriggerPs5::VIBRATIONSTRENGTH = 7;
+const int GlobalVariables::HapticTriggerPs5::RANGE = 320;
+const int GlobalVariables::HapticTriggerPs5::FREQUENCY = 32;
+
 #ifdef WITH_X11
 
 // ---- X11EXTRAS ---- //

--- a/src/globalvariables.h
+++ b/src/globalvariables.h
@@ -123,6 +123,15 @@ class JoyAxis
     static const QString xmlName;
 };
 
+class HapticTriggerPs5
+{
+  public:
+    static const int STRENGTH;
+    static const int VIBRATIONSTRENGTH;
+    static const int RANGE;
+    static const int FREQUENCY;
+};
+
 #ifdef WITH_X11
 
 class X11Extras

--- a/src/gui/axiseditdialog.cpp
+++ b/src/gui/axiseditdialog.cpp
@@ -59,11 +59,11 @@ AxisEditDialog::AxisEditDialog(JoyAxis *axis, bool keypadUnlocked, QWidget *pare
     if (actAsTrigger)
         buildTriggerPresetsMenu();
 
-    ui->horizontalSlider->setValue(axis->getDeadZone());
-    ui->lineEdit->setText(QString::number(axis->getDeadZone()));
+    ui->deadZoneSlider->setValue(axis->getDeadZone());
+    ui->deadZoneSpinBox->setValue(axis->getDeadZone());
 
-    ui->horizontalSlider_2->setValue(axis->getMaxZoneValue());
-    ui->lineEdit_2->setText(QString::number(axis->getMaxZoneValue()));
+    ui->maxZoneSlider->setValue(axis->getMaxZoneValue());
+    ui->maxZoneSpinBox->setValue(axis->getMaxZoneValue());
 
     JoyAxisButton *nButton = axis->getNAxisButton();
 
@@ -91,14 +91,14 @@ AxisEditDialog::AxisEditDialog(JoyAxis *axis, bool keypadUnlocked, QWidget *pare
         (currentThrottle == static_cast<int>(JoyAxis::NegativeHalfThrottle)))
     {
         int tempindex = (currentThrottle == static_cast<int>(JoyAxis::NegativeHalfThrottle)) ? 0 : 1;
-        ui->comboBox_2->setCurrentIndex(tempindex);
+        ui->throttleComboBox->setCurrentIndex(tempindex);
         ui->nPushButton->setEnabled(true);
         ui->pPushButton->setEnabled(false);
     } else if ((currentThrottle == static_cast<int>(JoyAxis::PositiveThrottle)) ||
                (currentThrottle == static_cast<int>(JoyAxis::PositiveHalfThrottle)))
     {
         int tempindex = (currentThrottle == static_cast<int>(JoyAxis::PositiveThrottle)) ? 3 : 4;
-        ui->comboBox_2->setCurrentIndex(tempindex);
+        ui->throttleComboBox->setCurrentIndex(tempindex);
         ui->pPushButton->setEnabled(true);
         ui->nPushButton->setEnabled(false);
     }
@@ -120,29 +120,31 @@ AxisEditDialog::AxisEditDialog(JoyAxis *axis, bool keypadUnlocked, QWidget *pare
     connect(ui->presetsComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             &AxisEditDialog::implementPresets);
 
-    connect(ui->horizontalSlider, &QSlider::valueChanged, this, &AxisEditDialog::updateDeadZoneBox);
-    connect(ui->horizontalSlider, &QSlider::valueChanged, this,
+    connect(ui->deadZoneSlider, &QSlider::valueChanged, this, &AxisEditDialog::updateDeadZoneBox);
+    connect(ui->deadZoneSlider, &QSlider::valueChanged, this,
             [this, axis](int deadzone) { ui->axisstatusBox->setDeadZone(axis, deadzone); });
 
-    connect(ui->horizontalSlider, &QSlider::valueChanged, axis, &JoyAxis::setDeadZone);
+    connect(ui->deadZoneSlider, &QSlider::valueChanged, axis, &JoyAxis::setDeadZone);
 
-    connect(ui->horizontalSlider_2, &QSlider::valueChanged, this, &AxisEditDialog::updateMaxZoneBox);
-    connect(ui->horizontalSlider_2, &QSlider::valueChanged, this,
+    connect(ui->maxZoneSlider, &QSlider::valueChanged, this, &AxisEditDialog::updateMaxZoneBox);
+    connect(ui->maxZoneSlider, &QSlider::valueChanged, this,
             [this, axis](int deadzone) { ui->axisstatusBox->setMaxZone(axis, deadzone); });
 
-    connect(ui->horizontalSlider_2, &QSlider::valueChanged, axis, &JoyAxis::setMaxZoneValue);
+    connect(ui->maxZoneSlider, &QSlider::valueChanged, axis, &JoyAxis::setMaxZoneValue);
 
-    connect(ui->comboBox_2, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+    connect(ui->throttleComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             &AxisEditDialog::updateThrottleUi);
-    connect(ui->comboBox_2, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+    connect(ui->throttleComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             &AxisEditDialog::presetForThrottleChange);
 
     connect(axis, &JoyAxis::moved, this, [this, axis](int value) { ui->axisstatusBox->setValue(axis, value); });
 
     connect(axis, &JoyAxis::moved, this, &AxisEditDialog::updateJoyValue);
 
-    connect(ui->lineEdit, &QLineEdit::textEdited, this, &AxisEditDialog::updateDeadZoneSlider);
-    connect(ui->lineEdit_2, &QLineEdit::textEdited, this, &AxisEditDialog::updateMaxZoneSlider);
+    connect(ui->deadZoneSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            &AxisEditDialog::updateDeadZoneSlider);
+    connect(ui->maxZoneSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            &AxisEditDialog::updateMaxZoneSlider);
 
     connect(ui->nPushButton, &QPushButton::clicked, this, &AxisEditDialog::openAdvancedNDialog);
     connect(ui->pPushButton, &QPushButton::clicked, this, &AxisEditDialog::openAdvancedPDialog);
@@ -298,9 +300,9 @@ void AxisEditDialog::implementAxisPresets(int index)
     PadderCommon::unlockInputDevices();
 }
 
-void AxisEditDialog::updateDeadZoneBox(int value) { ui->lineEdit->setText(QString::number(value)); }
+void AxisEditDialog::updateDeadZoneBox(int value) { ui->deadZoneSpinBox->setValue(value); }
 
-void AxisEditDialog::updateMaxZoneBox(int value) { ui->lineEdit_2->setText(QString::number(value)); }
+void AxisEditDialog::updateMaxZoneBox(int value) { ui->maxZoneSpinBox->setValue(value); }
 
 void AxisEditDialog::updateThrottleUi(int index)
 {
@@ -331,23 +333,19 @@ void AxisEditDialog::updateThrottleUi(int index)
 
 void AxisEditDialog::updateJoyValue(int value) { ui->joyValueLabel->setText(QString::number(value)); }
 
-void AxisEditDialog::updateDeadZoneSlider(QString value)
+void AxisEditDialog::updateDeadZoneSlider(int value)
 {
-    int temp = value.toInt();
-
-    if ((temp >= GlobalVariables::JoyAxis::AXISMIN) && (temp <= GlobalVariables::JoyAxis::AXISMAX))
+    if ((value >= GlobalVariables::JoyAxis::AXISMIN) && (value <= GlobalVariables::JoyAxis::AXISMAX))
     {
-        ui->horizontalSlider->setValue(temp);
+        ui->deadZoneSlider->setValue(value);
     }
 }
 
-void AxisEditDialog::updateMaxZoneSlider(QString value)
+void AxisEditDialog::updateMaxZoneSlider(int value)
 {
-    int temp = value.toInt();
-
-    if ((temp >= GlobalVariables::JoyAxis::AXISMIN) && (temp <= GlobalVariables::JoyAxis::AXISMAX))
+    if ((value >= GlobalVariables::JoyAxis::AXISMIN) && (value <= GlobalVariables::JoyAxis::AXISMAX))
     {
-        ui->horizontalSlider_2->setValue(temp);
+        ui->maxZoneSlider->setValue(value);
     }
 }
 

--- a/src/gui/axiseditdialog.h
+++ b/src/gui/axiseditdialog.h
@@ -63,8 +63,8 @@ class AxisEditDialog : public QDialog
     void updateMaxZoneBox(int value);
     void updateThrottleUi(int index);
     void updateJoyValue(int value);
-    void updateDeadZoneSlider(QString value);
-    void updateMaxZoneSlider(QString value);
+    void updateDeadZoneSlider(int value);
+    void updateMaxZoneSlider(int value);
     void openAdvancedPDialog();
     void openAdvancedNDialog();
 

--- a/src/gui/axiseditdialog.h
+++ b/src/gui/axiseditdialog.h
@@ -41,11 +41,23 @@ class AxisEditDialog : public QDialog
   protected:
     void selectAxisCurrentPreset();
     void selectTriggerPreset();
+    void selectHapticTrigger();
 
     void buildTriggerPresetsMenu();
     void buildAxisPresetsMenu();
+    void buildHapticTriggerMenu();
 
   private:
+    /**
+     * @brief Haptic trigger combo box indices.
+     */
+    enum HapticTriggerIndex
+    {
+        HAPTIC_TRIGGER_NONE_INDEX,
+        HAPTIC_TRIGGER_CLICK_INDEX,
+        HAPTIC_TRIGGER_RIGID_INDEX,
+        HAPTIC_TRIGGER_VIBRATION_INDEX
+    };
     Ui::AxisEditDialog *ui;
 
     JoyAxis *m_axis;
@@ -58,6 +70,7 @@ class AxisEditDialog : public QDialog
     void implementTriggerPresets(int index);
     void implementPresets(int index);
     void presetForThrottleChange(int index);
+    void implementHapticTrigger(int index);
 
     void updateDeadZoneBox(int value);
     void updateMaxZoneBox(int value);

--- a/src/gui/axiseditdialog.ui
+++ b/src/gui/axiseditdialog.ui
@@ -410,6 +410,16 @@ interpret an axis hold or release.</string>
        </item>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="hapticTriggerLabel">
+       <property name="text">
+        <string>Haptic Trigger:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QComboBox" name="hapticTriggerComboBox"/>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/gui/axiseditdialog.ui
+++ b/src/gui/axiseditdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
-    <height>369</height>
+    <width>682</width>
+    <height>503</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -137,12 +137,12 @@
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+      <enum>QSizePolicy::MinimumExpanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>20</height>
+       <height>32</height>
       </size>
      </property>
     </spacer>
@@ -150,49 +150,40 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <property name="topMargin">
-      <number>10</number>
+      <number>0</number>
      </property>
      <property name="bottomMargin">
-      <number>10</number>
+      <number>0</number>
      </property>
-     <property name="horizontalSpacing">
-      <number>10</number>
+     <property name="spacing">
+      <number>4</number>
      </property>
      <item row="1" column="2">
-      <widget class="QLineEdit" name="lineEdit_2">
+      <widget class="QSpinBox" name="maxZoneSpinBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="maximumSize">
+       <property name="minimumSize">
         <size>
-         <width>100</width>
-         <height>16777215</height>
+         <width>32</width>
+         <height>0</height>
         </size>
-       </property>
-       <property name="mouseTracking">
-        <bool>false</bool>
-       </property>
-       <property name="acceptDrops">
-        <bool>false</bool>
        </property>
        <property name="toolTip">
         <string>Set the value to use as the limit for an axis. Useful for a
 worn out analog stick.</string>
        </property>
-       <property name="inputMask">
-        <string notr="true"/>
+       <property name="minimum">
+        <number>1</number>
        </property>
-       <property name="text">
-        <string/>
+       <property name="maximum">
+        <number>32737</number>
        </property>
-       <property name="maxLength">
-        <number>5</number>
-       </property>
-       <property name="readOnly">
-        <bool>false</bool>
+       <property name="value">
+        <number>32000</number>
        </property>
       </widget>
      </item>
@@ -204,7 +195,13 @@ worn out analog stick.</string>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QSlider" name="horizontalSlider">
+      <widget class="QSlider" name="deadZoneSlider">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Set the value of the dead zone for an axis.</string>
        </property>
@@ -247,50 +244,35 @@ worn out analog stick.</string>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLineEdit" name="lineEdit">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
+      <widget class="QSpinBox" name="deadZoneSpinBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="maximumSize">
+       <property name="minimumSize">
         <size>
-         <width>100</width>
-         <height>16777215</height>
+         <width>32</width>
+         <height>0</height>
         </size>
-       </property>
-       <property name="mouseTracking">
-        <bool>false</bool>
-       </property>
-       <property name="acceptDrops">
-        <bool>false</bool>
        </property>
        <property name="toolTip">
         <string>Set the value of the dead zone for an axis.</string>
        </property>
-       <property name="inputMask">
-        <string notr="true"/>
+       <property name="minimum">
+        <number>1</number>
        </property>
-       <property name="text">
-        <string/>
+       <property name="maximum">
+        <number>32737</number>
        </property>
-       <property name="maxLength">
-        <number>5</number>
-       </property>
-       <property name="frame">
-        <bool>true</bool>
-       </property>
-       <property name="readOnly">
-        <bool>false</bool>
+       <property name="value">
+        <number>5000</number>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QSlider" name="horizontalSlider_2">
+      <widget class="QSlider" name="maxZoneSlider">
        <property name="toolTip">
         <string>Set the value to use as the limit for an axis. Useful for a
 worn out analog stick.</string>
@@ -331,16 +313,63 @@ worn out analog stick.</string>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="nPushButton">
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>32</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,2,1">
+     <item row="0" column="2">
+      <widget class="QPushButton" name="pPushButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
         <string>[NO KEY]</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QComboBox" name="comboBox_2">
+     <item row="0" column="0">
+      <widget class="QPushButton" name="nPushButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>[NO KEY]</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="throttleComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>350</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Throttle setting that determines the behavior of how to
 interpret an axis hold or release.</string>
@@ -381,14 +410,23 @@ interpret an axis hold or release.</string>
        </item>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="pPushButton">
-       <property name="text">
-        <string>[NO KEY]</string>
-       </property>
-      </widget>
-     </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>32</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="AxisValueBox" name="axisstatusBox" native="true">
@@ -457,12 +495,12 @@ interpret an axis hold or release.</string>
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+      <enum>QSizePolicy::MinimumExpanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>20</height>
+       <height>32</height>
       </size>
      </property>
     </spacer>
@@ -495,8 +533,7 @@ interpret an axis hold or release.</string>
      </property>
      <property name="icon">
       <iconset theme="input-mouse">
-       <normaloff/>
-      </iconset>
+       <normaloff>.</normaloff>.</iconset>
      </property>
     </widget>
    </item>

--- a/src/haptictriggermodeps5.h
+++ b/src/haptictriggermodeps5.h
@@ -1,0 +1,30 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+/**
+ * @brief Enum of the supported haptic trigger effect modes of the
+ *   PS5 controller.
+ *   See https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db
+ */
+enum HapticTriggerModePs5
+{
+    HAPTIC_TRIGGER_NONE = 0x05,
+    HAPTIC_TRIGGER_CLICK = 0x25,
+    HAPTIC_TRIGGER_RIGID = 0x21,
+    HAPTIC_TRIGGER_VIBRATION = 0x26
+};

--- a/src/haptictriggerps5.cpp
+++ b/src/haptictriggerps5.cpp
@@ -288,3 +288,44 @@ void HapticTriggerPs5::to_message(TriggerEffectMsgPs5 &effect) const
         effect.vibration.build(m_start, m_end, m_strength, m_frequency);
     }
 }
+
+/**
+ * @brief Converts a HapticTriggerModePs5 from string representation.
+ */
+HapticTriggerModePs5 HapticTriggerPs5::from_string(const QString &name)
+{
+    HapticTriggerModePs5 mode = HAPTIC_TRIGGER_NONE;
+    if (name == "None")
+    {
+        mode = HAPTIC_TRIGGER_NONE;
+    } else if (name == "Click")
+    {
+        mode = HAPTIC_TRIGGER_CLICK;
+    } else if (name == "Rigid")
+    {
+        mode = HAPTIC_TRIGGER_RIGID;
+    } else if (name == "Vibration")
+    {
+        mode = HAPTIC_TRIGGER_VIBRATION;
+    }
+    return mode;
+}
+
+/**
+ * @brief Returns string representation of a HapticTriggerModePs5 object.
+ */
+QString HapticTriggerPs5::to_string(HapticTriggerModePs5 mode)
+{
+    switch (mode)
+    {
+    case HAPTIC_TRIGGER_NONE:
+        return "None";
+    case HAPTIC_TRIGGER_CLICK:
+        return "Click";
+    case HAPTIC_TRIGGER_RIGID:
+        return "Rigid";
+    case HAPTIC_TRIGGER_VIBRATION:
+        return "Vibration";
+    }
+    return "None";
+}

--- a/src/haptictriggerps5.cpp
+++ b/src/haptictriggerps5.cpp
@@ -1,0 +1,290 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "haptictriggerps5.h"
+
+#pragma pack(push, 1)
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+
+constexpr u16 u16tole(u16 x)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return x;
+#elif __BYTE_ORDER == _BIG_ENDIAN
+    return ((x << 8) & 0xFF00) | ((x >> 8) & 0x00FF);
+#else
+    #error "Target machine has unknown endianness!"
+#endif
+}
+
+constexpr u32 u32tole(u32 x)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return x;
+#elif __BYTE_ORDER == _BIG_ENDIAN
+    return ((x << 24) & 0xFF000000) | ((x << 8) & 0x00FF0000) | ((x >> 8) & 0x0000FF00) | ((x >> 24) & 0x000000FF);
+#else
+    #error "Target machine has unknown endianness!"
+#endif
+}
+
+/**
+ * @brief Effect message for no trigger effect.
+ */
+struct EffectNonePs5
+{
+    u8 _padding[10];
+
+    inline void build() { memset(_padding, 0, 10); }
+};
+
+/**
+ * @brief Effect message for a rigid trigger effect.
+ */
+struct EffectRigidPs5
+{
+    /// Defines if force feedback is active in the corresponding tenth of the trigger.
+    /// Bitfield of 10 right aligned bits.
+    u16 active_zones;
+    /// Defines the force feedback strength in the corresponding tenth of the trigger.
+    /// Bitfield of 30 right aligned bits. Every zone has three bits.
+    u32 force_zones;
+    u32 _padding;
+
+    /**
+     * @brief Builds a rigid effect message.
+     * @param[in] strength Strength of the feedback force. Value between 0 and 7.
+     */
+    inline void build(int strength)
+    {
+        active_zones = u16tole(0x03FF);
+        force_zones = 0;
+        for (int i = 0; i < 30; i += 3)
+            force_zones |= strength << i;
+        force_zones = u32tole(force_zones);
+        _padding = 0;
+    }
+};
+
+/**
+ * @brief Effect message for a click trigger effect.
+ */
+struct EffectClickPs5
+{
+    /// Bitfield with two set bits which define the start and stop zone of the effect.
+    /// The trigger is devided into 9 zones.
+    u16 start_stop_zone;
+    /// Strength of the feedback force. Value between 0 and 7.
+    u8 force;
+    u8 _padding[7];
+
+    /**
+     * @brief Builds a click effect message.
+     * @param[in] start Start point of the effect. Value between 2 and 7.
+     * @param[in] end End point of the effect.
+     *   Value between 2 and 8 which must be at least grater then start by two.
+     * @param[in] strength Strength of the feedback force. Value between 0 and 7.
+     */
+    inline void build(int start, int end, int strength)
+    {
+        start = qBound(2, start, 6);
+        end = qBound(start + 2, end, 8);
+
+        start_stop_zone = u16tole((1 << start) | (1 << end));
+        force = strength;
+        memset(_padding, 0, 7);
+    }
+};
+
+/**
+ * @brief Effect message for a vibration trigger effect.
+ */
+struct EffectVibrationPs5
+{
+    /// Defines if force feedback is active in the corresponding tenth of the trigger.
+    /// Bitfield of 10 right aligned bits.
+    u16 active_zones;
+    /// Defines the force feedback strength in the corresponding tenth of the trigger.
+    /// Bitfield of 30 right aligned bits. Every zone has three bits.
+    u32 amplitude_zones;
+    u16 _padding1;
+    /// Frequeny in Hz
+    u8 frequency;
+    u8 _padding2;
+
+    /**
+     * @brief Builds a vibration effect message.
+     * @param[in] start Start point of the effect. Value between 0 and 10.
+     * @param[in] end End point of the effect.
+     *   Value between 2 and 10 which must be at least grater then start by two.
+     * @param[in] strength Strength of the feedback force. Value between 0 and 7.
+     * @param[in] frequency Virbration frequency in Hz. Value between 1 and 255.
+     */
+    inline void build(int start, int end, int strength, int freq)
+    {
+        active_zones = 0;
+        amplitude_zones = 0;
+        for (int i = start; i <= end; ++i)
+        {
+            active_zones |= (1 << i);
+            amplitude_zones |= (strength << (3 * i));
+        }
+        active_zones = u16tole(active_zones);
+        amplitude_zones = u32tole(amplitude_zones);
+        _padding1 = 0;
+        frequency = freq;
+        _padding2 = 0;
+    }
+};
+
+/**
+ * @brief Effect message for a single trigger.
+ */
+struct TriggerEffectMsgPs5
+{
+    u8 mode;
+    union
+    {
+        EffectNonePs5 none;
+        EffectRigidPs5 rigid;
+        EffectClickPs5 click;
+        EffectVibrationPs5 vibration;
+    };
+};
+
+/**
+ * @brief Binary representation of a PS5 controller haptic feedback message.
+ */
+struct EffectMessagePs5
+{
+    u16 enable_bits = 0;
+    u8 rumble_right = 0;
+    u8 rumble_left = 0;
+    u8 headphone_volume = 0;
+    u8 speaker_volume = 255;
+    u8 microphone_volume = 0;
+    u8 audio_enable_bits = 0;
+    u8 mic_light_mode = 0;
+    u8 audio_mute_bits = 0;
+    TriggerEffectMsgPs5 right_trigger_effect;
+    TriggerEffectMsgPs5 left_trigger_effect;
+    u8 _reserved1[6] = {0};
+    u8 led_flags = 0;
+    u8 _reverved2[2] = {0};
+    u8 led_animation = 0;
+    u8 led_brightness = 0;
+    u8 pad_lights = 0;
+    u8 led_red = 0;
+    u8 led_green = 0;
+    u8 led_bBlue = 0;
+};
+#pragma pack(pop)
+
+HapticTriggerPs5::HapticTriggerPs5(QObject *parent, HapticTriggerModePs5 mode, int strength, int start, int end,
+                                   int frequency)
+    : QObject(parent)
+    , m_mode(mode)
+    , m_strength(strength)
+    , m_start(start)
+    , m_end(end)
+    , m_frequency(frequency)
+{
+}
+
+/**
+ * @brief Returns the current haptic feedback effect mode.
+ */
+HapticTriggerModePs5 HapticTriggerPs5::get_mode() const { return m_mode; }
+
+/**
+ * @brief Changes the haptic feedback mode to the given type.
+ * @param[in] mode New haptic feedback mode.
+ * @returns True when the mode was changed, false otherwise.
+ */
+bool HapticTriggerPs5::set_effect_mode(HapticTriggerModePs5 mode)
+{
+    bool changed = m_mode != mode;
+    m_mode = mode;
+    return changed;
+}
+
+/**
+ * @brief Changes the haptic feedback effect.
+ * @param[in] strength Strength of the feedback force between 0 and 255.
+ * @param[in] start Start point of the effect. Value between 0 and 320.
+ * @param[in] end End point of the effect. Value between 0 and 320.
+ * @param[in] frequency Frequency of the effect in Hz. Value between 1 and 255.
+ * @returns True when the effect was changed, false otherwise.
+ */
+bool HapticTriggerPs5::set_effect(int strength, int start, int end, int frequency)
+{
+    strength = qBound(0, strength / 32, 7);
+    start = qBound(0, start / 31, 8);
+    end = qBound(0, end / 31, 10);
+    frequency = qBound(1, frequency, 255);
+
+    bool changed = m_strength != strength || m_start != start || m_end != end || m_frequency != frequency;
+    m_strength = strength;
+    m_start = start;
+    m_end = end;
+    m_frequency = frequency;
+    return changed;
+}
+
+/**
+ * @brief Creates an low level message from two HapticTriggerPs5 objects and
+ *   send them to the controller.
+ * @param[in] controller Controller to which the message is send.
+ * @param[in] left HapticTriggerPs5 effect for the left trigger.
+ * @param[in] right HapticTriggerPs5 effect for the right trigger.
+ */
+void HapticTriggerPs5::send(SDL_GameController *controller, const HapticTriggerPs5 &left, const HapticTriggerPs5 &right)
+{
+    EffectMessagePs5 message;
+    message.enable_bits |= EFFECT_LEFT_EN | EFFECT_RIGHT_EN;
+
+    left.to_message(message.left_trigger_effect);
+    right.to_message(message.right_trigger_effect);
+
+    SDL_GameControllerSendEffect(controller, &message, sizeof(EffectMessagePs5));
+}
+
+/**
+ * @brief Low level function to write one HapticTriggerPs5 effect into a PS5
+ *   controller message.
+ * @param[in] effect Pointer to the triggers effect data position
+ *   in the effect message.
+ */
+void HapticTriggerPs5::to_message(TriggerEffectMsgPs5 &effect) const
+{
+    effect.mode = m_mode;
+    switch (m_mode)
+    {
+    case HAPTIC_TRIGGER_NONE:
+        effect.none.build();
+        return;
+    case HAPTIC_TRIGGER_CLICK:
+        effect.click.build(m_start, m_end, m_strength);
+        return;
+    case HAPTIC_TRIGGER_RIGID:
+        effect.rigid.build(m_strength);
+        return;
+    case HAPTIC_TRIGGER_VIBRATION:
+        effect.vibration.build(m_start, m_end, m_strength, m_frequency);
+    }
+}

--- a/src/haptictriggerps5.cpp
+++ b/src/haptictriggerps5.cpp
@@ -16,6 +16,8 @@
  */
 #include "haptictriggerps5.h"
 
+#include <SDL2/SDL.h>
+
 #pragma pack(push, 1)
 typedef uint8_t u8;
 typedef uint16_t u16;
@@ -255,6 +257,7 @@ bool HapticTriggerPs5::set_effect(int strength, int start, int end, int frequenc
  */
 void HapticTriggerPs5::send(SDL_GameController *controller, const HapticTriggerPs5 &left, const HapticTriggerPs5 &right)
 {
+#if SDL_VERSION_ATLEAST(2, 0, 16)
     EffectMessagePs5 message;
     message.enable_bits |= EFFECT_LEFT_EN | EFFECT_RIGHT_EN;
 
@@ -262,6 +265,7 @@ void HapticTriggerPs5::send(SDL_GameController *controller, const HapticTriggerP
     right.to_message(message.right_trigger_effect);
 
     SDL_GameControllerSendEffect(controller, &message, sizeof(EffectMessagePs5));
+#endif
 }
 
 /**

--- a/src/haptictriggerps5.h
+++ b/src/haptictriggerps5.h
@@ -41,6 +41,8 @@ class HapticTriggerPs5 : QObject
     bool set_effect(int strength, int start, int end, int frequency = 0);
 
     static void send(SDL_GameController *controller, const HapticTriggerPs5 &left, const HapticTriggerPs5 &right);
+    static HapticTriggerModePs5 from_string(const QString &mode);
+    static QString to_string(HapticTriggerModePs5 mode);
 
   private:
     enum

--- a/src/haptictriggerps5.h
+++ b/src/haptictriggerps5.h
@@ -1,0 +1,65 @@
+/* antimicrox Gamepad to KB+M event mapper
+ * Copyright (C) 2022 Max Maisel <max.maisel@posteo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <SDL2/SDL_gamecontroller.h>
+#include <stdint.h>
+
+#include "haptictriggermodeps5.h"
+
+struct TriggerEffectMsgPs5;
+
+/**
+ * @brief Represents a single haptic trigger effect on a PS5 controller.
+ *   See https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db
+ *   and https://github.com/Electronicks/JoyShockMapper/blob/master/JoyShockMapper/src/SDL2Wrapper.cpp
+ */
+class HapticTriggerPs5 : QObject
+{
+  public:
+    explicit HapticTriggerPs5(QObject *parent, HapticTriggerModePs5 mode = HAPTIC_TRIGGER_NONE, int strength = 0,
+                              int start = 0, int end = 0, int frequency = 0);
+
+    HapticTriggerModePs5 get_mode() const;
+    bool set_effect_mode(HapticTriggerModePs5 mode);
+    bool set_effect(int strength, int start, int end, int frequency = 0);
+
+    static void send(SDL_GameController *controller, const HapticTriggerPs5 &left, const HapticTriggerPs5 &right);
+
+  private:
+    enum
+    {
+        EFFECT_LEFT_EN = 0x04,
+        EFFECT_RIGHT_EN = 0x08,
+        LEGACY_RUMBLE_LEFT_EN = 0x0001,
+        LEGACY_RUMBLE_RIGHT_EN = 0x0002,
+        MICROPHONE_LIGHT_EN = 0x0100,
+
+        MICROPHONE_LIGHT_OFF = 0x00,
+        MICROPHONE_LIGHT_SOLID = 0x01,
+        MICROPHONE_LIGHT_PULSE = 0x02
+    };
+    HapticTriggerModePs5 m_mode;
+    int m_strength;
+    int m_start;
+    int m_end;
+    int m_frequency;
+
+    void to_message(TriggerEffectMsgPs5 &effect) const;
+};

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1752,6 +1752,12 @@ QList<int> &InputDevice::getDpadstatesLocal() { return dpadstates; }
 SDL_Joystick *InputDevice::getJoyHandle() const { return m_joyhandle; }
 
 /**
+ * @brief Returns the current controller model.
+ *   For non gamecontroller devices it always returns UNKNOWN.
+ */
+SDL_GameControllerType InputDevice::getControllerType() const { return SDL_CONTROLLER_TYPE_UNKNOWN; }
+
+/**
  * @brief Returns a pointer to the internal calibration storage backend.
  */
 InputDeviceCalibration *InputDevice::getCalibrationBackend() { return &m_calibrations; }

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -32,6 +32,13 @@ class QXmlStreamReader;
 class QXmlStreamWriter;
 class QSettings;
 
+#if not SDL_VERSION_ATLEAST(2, 0, 16)
+enum SDL_GameControllerType
+{
+    SDL_CONTROLLER_TYPE_UNKNOWN = 0
+};
+#endif
+
 /**
  * @brief Represents a hardware input device, e.g a joystick or controller.
  */

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -149,6 +149,7 @@ class InputDevice : public QObject
 
     QHash<int, SetJoystick *> &getJoystick_sets();
     SDL_Joystick *getJoyHandle() const;
+    virtual SDL_GameControllerType getControllerType() const;
 
     InputDeviceCalibration *getCalibrationBackend();
     void updateStickCalibration(int index, double offsetX, double gainX, double offsetY, double gainY);

--- a/src/joyaxis.cpp
+++ b/src/joyaxis.cpp
@@ -353,8 +353,13 @@ void JoyAxis::createDeskEvent(bool ignoresets)
 
 void JoyAxis::setDeadZone(int value)
 {
-    deadZone = abs(value);
+    value = abs(value);
+    if (deadZone == value)
+        return;
+
+    deadZone = value;
     emit propertyUpdated();
+    emit hapticTriggerChanged();
 }
 
 int JoyAxis::getDeadZone() { return deadZone; }

--- a/src/joyaxis.cpp
+++ b/src/joyaxis.cpp
@@ -295,6 +295,23 @@ int JoyAxis::calculateThrottledValue(int value)
     return temp;
 }
 
+/**
+ * @brief Checks if the axis supports haptic trigger feedback.
+ * @returns True if the axis supports haptic trigger feedback, false otherwise.
+ */
+bool JoyAxis::hasHapticTrigger() const { return false; }
+
+/**
+ * @brief Always returns nullptr for JoyAxis base objects.
+ */
+HapticTriggerPs5 *JoyAxis::getHapticTrigger() const { return nullptr; }
+
+/**
+ * @brief Changes the haptic trigger effect mode.
+ * @param[in] mode New haptic trigger effect mode.
+ */
+void JoyAxis::setHapticTriggerMode(HapticTriggerModePs5) {}
+
 void JoyAxis::setIndex(int index) { m_index = index; }
 
 int JoyAxis::getIndex() { return m_index; }

--- a/src/joyaxis.h
+++ b/src/joyaxis.h
@@ -41,7 +41,7 @@ class JoyAxis : public QObject
 
   public:
     explicit JoyAxis(int index, int originset, SetJoystick *parentSet, QObject *parent);
-    ~JoyAxis();
+    virtual ~JoyAxis();
 
     enum ThrottleTypes
     {

--- a/src/joyaxis.h
+++ b/src/joyaxis.h
@@ -22,8 +22,10 @@
 #include <QList>
 #include <QObject>
 
+#include "haptictriggermodeps5.h"
 #include "joybuttontypes/joyaxisbutton.h"
 
+class HapticTriggerPs5;
 class JoyControlStick;
 class SetJoystick;
 class JoyAxisButton;
@@ -153,6 +155,10 @@ class JoyAxis : public QObject
     static const ThrottleTypes DEFAULTTHROTTLE;
     int calculateThrottledValue(int value);
 
+    virtual bool hasHapticTrigger() const;
+    virtual HapticTriggerPs5 *getHapticTrigger() const;
+    virtual void setHapticTriggerMode(HapticTriggerModePs5);
+
   protected:
     void createDeskEvent(bool ignoresets = false); // JoyAxisEvent class
     void adjustRange();
@@ -195,6 +201,7 @@ class JoyAxis : public QObject
     void throttleChanged();
     void axisNameChanged();
     void propertyUpdated();
+    void hapticTriggerChanged();
 
   public slots:
     virtual void reset();

--- a/src/xml/joyaxisxml.cpp
+++ b/src/xml/joyaxisxml.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "joyaxisxml.h"
+#include "haptictriggerps5.h"
 #include "inputdevice.h"
 #include "joyaxis.h"
 #include "joybuttontypes/joyaxisbutton.h"
@@ -108,6 +109,12 @@ void JoyAxisXml::writeConfig(QXmlStreamWriter *xml)
 
     xml->writeEndElement();
 
+    if (m_joyAxis->hasHapticTrigger())
+    {
+        HapticTriggerPs5 *haptic = m_joyAxis->getHapticTrigger();
+        xml->writeTextElement("hapticTrigger", HapticTriggerPs5::to_string(haptic->get_mode()));
+    }
+
     if (!currentlyDefault)
     {
         joyButtonXmlNAxis->writeConfig(xml);
@@ -173,6 +180,10 @@ bool JoyAxisXml::readMainConfig(QXmlStreamReader *xml)
 
         m_joyAxis->setCurrentRawValue(m_joyAxis->getCurrentThrottledDeadValue());
         m_joyAxis->updateCurrentThrottledValue(m_joyAxis->calculateThrottledValue(m_joyAxis->getCurrentRawValue()));
+    } else if ((xml->name() == "hapticTrigger") && xml->isStartElement())
+    {
+        found = true;
+        m_joyAxis->setHapticTriggerMode(HapticTriggerPs5::from_string(xml->readElementText()));
     }
 
     return found;


### PR DESCRIPTION
Add support for DualSense trigger haptic feedback if SDL version is greater or equal to 2.0.16.
There are two supported effects, click and rigid which can be configured the the axis edit dialog
if a DualSense controller is connected. The feedback point follows the trigger point, i.e. the configured dead-zone.

In preparation of this change, remove some dead XML related code and clean-up the axis edit dialog.