### PR TITLE
Improve trigger effect exactness.

### DIFF
--- a/src/gamecontroller/gamecontrollertrigger.cpp
+++ b/src/gamecontroller/gamecontrollertrigger.cpp
@@ -157,16 +157,16 @@ HapticTriggerPs5 *GameControllerTrigger::getHapticTrigger() const
         m_haptic_trigger->set_effect(0, 0, 0);
         break;
     case HAPTIC_TRIGGER_CLICK:
-        start = double(deadZone) * 192 / GlobalVariables::JoyAxis::AXISMAX;
-        end = start + 65;
-        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::STRENGTH, start, end);
+        end = std::max(160, 200 * deadZone / GlobalVariables::JoyAxis::AXISMAX + 60);
+        start = end - 97;
+        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::CLICKSTRENGTH, start, end);
         break;
     case HAPTIC_TRIGGER_RIGID:
-        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::STRENGTH, 0,
+        m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::RIGIDSTRENGTH, 0,
                                      GlobalVariables::HapticTriggerPs5::RANGE);
         break;
     case HAPTIC_TRIGGER_VIBRATION:
-        start = double(deadZone) * 192 / GlobalVariables::JoyAxis::AXISMAX;
+        start = 200 * deadZone / GlobalVariables::JoyAxis::AXISMAX;
         m_haptic_trigger->set_effect(GlobalVariables::HapticTriggerPs5::VIBRATIONSTRENGTH, start,
                                      GlobalVariables::HapticTriggerPs5::RANGE, GlobalVariables::HapticTriggerPs5::FREQUENCY);
         break;

--- a/src/globalvariables.cpp
+++ b/src/globalvariables.cpp
@@ -117,7 +117,8 @@ const float GlobalVariables::JoyAxis::JOYSPEED = 20.0;
 
 const QString GlobalVariables::JoyAxis::xmlName = "axis";
 
-const int GlobalVariables::HapticTriggerPs5::STRENGTH = 4;
+const int GlobalVariables::HapticTriggerPs5::CLICKSTRENGTH = 7;
+const int GlobalVariables::HapticTriggerPs5::RIGIDSTRENGTH = 4;
 const int GlobalVariables::HapticTriggerPs5::VIBRATIONSTRENGTH = 7;
 const int GlobalVariables::HapticTriggerPs5::RANGE = 320;
 const int GlobalVariables::HapticTriggerPs5::FREQUENCY = 32;

--- a/src/globalvariables.h
+++ b/src/globalvariables.h
@@ -126,7 +126,8 @@ class JoyAxis
 class HapticTriggerPs5
 {
   public:
-    static const int STRENGTH;
+    static const int CLICKSTRENGTH;
+    static const int RIGIDSTRENGTH;
     static const int VIBRATIONSTRENGTH;
     static const int RANGE;
     static const int FREQUENCY;

--- a/src/haptictriggerps5.cpp
+++ b/src/haptictriggerps5.cpp
@@ -98,8 +98,12 @@ struct EffectClickPs5
     /**
      * @brief Builds a click effect message.
      * @param[in] start Start point of the effect. Value between 2 and 7.
+     *   2 is the middle of the trigger range, 7 the end.
+     *   This defines the position where the resistance starts.
      * @param[in] end End point of the effect.
      *   Value between 2 and 8 which must be at least grater then start by two.
+     *   2 is the middle of the trigger range, 8 the end.
+     *   This defines the position where the trigger "clicks".
      * @param[in] strength Strength of the feedback force. Value between 0 and 7.
      */
     inline void build(int start, int end, int strength)
@@ -132,6 +136,7 @@ struct EffectVibrationPs5
     /**
      * @brief Builds a vibration effect message.
      * @param[in] start Start point of the effect. Value between 0 and 10.
+     *   0 is the beginning of the trigger range, 10 the end.
      * @param[in] end End point of the effect.
      *   Value between 2 and 10 which must be at least grater then start by two.
      * @param[in] strength Strength of the feedback force. Value between 0 and 7.


### PR DESCRIPTION
The click and vibration effect start/end points did not optimally match
the trigger point of the axis.
Adjust the formulas to improve it.