### PR TITLE
fix: Remove hardcoded values for Gamepad class

### DIFF
--- a/src/gamecontroller/gamecontroller.cpp
+++ b/src/gamecontroller/gamecontroller.cpp
@@ -181,15 +181,6 @@ void GameController::closeSDLDevice()
     }
 }
 
-int GameController::getNumberRawButtons() { return SDL_CONTROLLER_BUTTON_MAX; }
-
-int GameController::getNumberRawAxes()
-{
-    qDebug() << "Controller has " << SDL_CONTROLLER_AXIS_MAX << " raw axes";
-
-    return SDL_CONTROLLER_AXIS_MAX;
-}
-
 /**
  * @brief Queries the data rate of the given sensor from SDL.
  * @returns Data rate in events per second or zero if data rate is unavailable.
@@ -222,8 +213,6 @@ bool GameController::hasRawSensor(JoySensorType type)
 #endif
     return false;
 }
-
-int GameController::getNumberRawHats() { return 0; }
 
 void GameController::setCounterUniques(int counter) { counterUniques = counter; }
 

--- a/src/gamecontroller/gamecontroller.h
+++ b/src/gamecontroller/gamecontroller.h
@@ -57,9 +57,6 @@ class GameController : public InputDevice
     virtual void closeSDLDevice() override;
     virtual SDL_JoystickID getSDLJoystickID() override;
 
-    virtual int getNumberRawButtons() override;
-    virtual int getNumberRawAxes() override;
-    virtual int getNumberRawHats() override;
     virtual double getRawSensorRate(JoySensorType type) override;
     virtual bool hasRawSensor(JoySensorType type) override;
     void setCounterUniques(int counter) override;

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1353,6 +1353,12 @@ QString InputDevice::getDescription()
     return full_desc;
 }
 
+int InputDevice::getNumberRawAxes() { return SDL_JoystickNumAxes(m_joyhandle); }
+
+int InputDevice::getNumberRawButtons() { return SDL_JoystickNumButtons(m_joyhandle); }
+
+int InputDevice::getNumberRawHats() { return SDL_JoystickNumHats(m_joyhandle); }
+
 QString InputDevice::getSDLPlatform()
 {
     QString temp = SDL_GetPlatform();

--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -105,9 +105,9 @@ class InputDevice : public QObject
     void setDPadName(int dpadIndex, QString tempName);   // InputDeviceHat class
     void setVDPadName(int vdpadIndex, QString tempName); // InputDeviceVDPad class
 
-    virtual int getNumberRawButtons() = 0;
-    virtual int getNumberRawAxes() = 0;
-    virtual int getNumberRawHats() = 0;
+    virtual int getNumberRawButtons();
+    virtual int getNumberRawAxes();
+    virtual int getNumberRawHats();
     virtual double getRawSensorRate(JoySensorType type) = 0;
     virtual bool hasRawSensor(JoySensorType type) = 0;
 

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -151,24 +151,6 @@ void Joystick::closeSDLDevice()
     }
 }
 
-int Joystick::getNumberRawButtons()
-{
-    int numbuttons = SDL_JoystickNumButtons(m_joyhandle);
-    return numbuttons;
-}
-
-int Joystick::getNumberRawAxes()
-{
-    int numaxes = SDL_JoystickNumAxes(m_joyhandle);
-    return numaxes;
-}
-
-int Joystick::getNumberRawHats()
-{
-    int numhats = SDL_JoystickNumHats(m_joyhandle);
-    return numhats;
-}
-
 double Joystick::getRawSensorRate(JoySensorType _) { return 0; }
 
 bool Joystick::hasRawSensor(JoySensorType _) { return false; }

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -44,9 +44,6 @@ class Joystick : public InputDevice
     virtual void closeSDLDevice() override;
     virtual SDL_JoystickID getSDLJoystickID() override;
 
-    virtual int getNumberRawButtons() override;
-    virtual int getNumberRawAxes() override;
-    virtual int getNumberRawHats() override;
     virtual double getRawSensorRate(JoySensorType type) override;
     virtual bool hasRawSensor(JoySensorType type) override;
 


### PR DESCRIPTION
It caused showing too many unused buttons for gamepads

Discovered thank to comment: https://github.com/AntiMicroX/antimicrox/issues/307#issue-1070082847 pointing at 21 unused buttons on gamepad