### PR TITLE
Thread fixes

### DIFF
--- a/src/gui/addeditautoprofiledialog.cpp
+++ b/src/gui/addeditautoprofiledialog.cpp
@@ -255,19 +255,21 @@ void AddEditAutoProfileDialog::showCaptureHelpWindow()
         box->show();
 
         UnixCaptureWindowUtility *util = new UnixCaptureWindowUtility();
-        QThread *thread = new QThread; // QTHREAD(this)
-        util->moveToThread(thread);
+        QThread *capture_window_thr = new QThread; // QTHREAD(this)
+        capture_window_thr->setObjectName("capture_window_thr");
 
-        connect(thread, &QThread::started, util, &UnixCaptureWindowUtility::attemptWindowCapture);
-        connect(util, &UnixCaptureWindowUtility::captureFinished, thread, &QThread::quit);
+        util->moveToThread(capture_window_thr);
+
+        connect(capture_window_thr, &QThread::started, util, &UnixCaptureWindowUtility::attemptWindowCapture);
+        connect(util, &UnixCaptureWindowUtility::captureFinished, capture_window_thr, &QThread::quit);
         connect(util, &UnixCaptureWindowUtility::captureFinished, box, &QMessageBox::hide);
         connect(
             util, &UnixCaptureWindowUtility::captureFinished, this, [this, util]() { checkForGrabbedWindow(util); },
             Qt::QueuedConnection);
 
-        connect(thread, &QThread::finished, box, &QMessageBox::deleteLater);
-        connect(util, &UnixCaptureWindowUtility::destroyed, thread, &QThread::deleteLater);
-        thread->start();
+        connect(capture_window_thr, &QThread::finished, box, &QMessageBox::deleteLater);
+        connect(util, &UnixCaptureWindowUtility::destroyed, capture_window_thr, &QThread::deleteLater);
+        capture_window_thr->start();
     }
 
     #endif

--- a/src/inputdaemon.cpp
+++ b/src/inputdaemon.cpp
@@ -56,6 +56,7 @@ InputDaemon::InputDaemon(QMap<SDL_JoystickID, InputDevice *> *joysticks, AntiMic
     if (m_graphical)
     {
         sdlWorkerThread = new QThread;
+        sdlWorkerThread->setObjectName("sdlWorkerThread");
         eventWorker->moveToThread(sdlWorkerThread);
 
         connect(sdlWorkerThread, &QThread::started, eventWorker, &SDLEventReader::performWork);

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -42,6 +42,7 @@ Logger::Logger(QTextStream *stream, LogLevel output_lvl, QObject *parent)
     // needed to allow sending LogLevel using signals and slots
     qRegisterMetaType<Logger::LogLevel>("Logger::LogLevel");
     loggingThread = new QThread(this);
+    loggingThread->setObjectName("loggingThread");
     outputStream = stream;
     outputLevel = output_lvl;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -561,6 +561,7 @@ int main(int argc, char *argv[])
     PadderCommon::mouseHelperObj.initDeskWid();
     QPointer<InputDaemon> joypad_worker = new InputDaemon(joysticks, &settings);
     inputEventThread = new QThread();
+    inputEventThread->setObjectName("inputEventThread");
 
     MainWindow *mainWindow = new MainWindow(joysticks, &cmdutility, &settings);
 

--- a/src/xml/inputdevicexml.h
+++ b/src/xml/inputdevicexml.h
@@ -41,8 +41,11 @@ class InputDeviceXml : public QObject
 
   public slots:
 
-    virtual void readConfig(QXmlStreamReader *xml);  // InputDeviceXml class
-    virtual void writeConfig(QXmlStreamWriter *xml); // InputDeviceXml class
+    void readConfig(QXmlStreamReader *xml);  // InputDeviceXml class
+    void writeConfig(QXmlStreamWriter *xml); // InputDeviceXml class
+
+  signals:
+    void readConfigSig(QXmlStreamReader *xml);
 
   private:
     InputDevice *m_inputDevice;

--- a/src/xmlconfigreader.cpp
+++ b/src/xmlconfigreader.cpp
@@ -63,9 +63,6 @@ XMLConfigReader::~XMLConfigReader()
         delete xml;
         xml = nullptr;
     }
-
-    if (!m_joystickXml.isNull())
-        delete m_joystickXml;
 }
 
 void XMLConfigReader::setJoystick(InputDevice *joystick) { m_joystick = joystick; }
@@ -148,9 +145,9 @@ bool XMLConfigReader::read()
         {
             if (xml->isStartElement() && deviceTypes.contains(xml->name().toString()))
             {
-                m_joystickXml = new InputDeviceXml(m_joystick);
-                m_joystickXml->readConfig(xml);
-                // if (!m_joystickXml.isNull()) delete m_joystickXml;
+                InputDeviceXml *joystick_xml = new InputDeviceXml(m_joystick);
+                joystick_xml->readConfig(xml);
+                joystick_xml->deleteLater();
             } else
             {
                 // If none of the above, skip the element

--- a/src/xmlconfigreader.h
+++ b/src/xmlconfigreader.h
@@ -20,7 +20,6 @@
 #define XMLCONFIGREADER_H
 
 #include <QObject>
-#include <QPointer>
 #include <QStringList>
 
 class InputDevice;
@@ -48,7 +47,6 @@ class XMLConfigReader : public QObject
     QString const &getFileName();
     const QFile *getConfigFile();
     const InputDevice *getJoystick();
-    QPointer<InputDeviceXml> m_joystickXml;
     QStringList const &getDeviceTypes();
 
   protected:


### PR DESCRIPTION
Closes: https://github.com/AntiMicroX/antimicrox/issues/238   
Closes: https://github.com/AntiMicroX/antimicrox/issues/274

Some cleanups and fix improving execution of config reading.   
It should help with warnings:

`WARN	QObject: Cannot create children for a parent that is in a different thread`

And other related problems