### PR TITLE
fix: Use proper theme-based color for tab text

### DIFF
--- a/src/gui/joytabwidgetcontainer.cpp
+++ b/src/gui/joytabwidgetcontainer.cpp
@@ -69,7 +69,7 @@ void JoyTabWidgetContainer::unflash(InputDevice *joystick)
         JoyTabWidget *tab = qobject_cast<JoyTabWidget *>(widget(i)); // static_cast
         if ((tab != nullptr) && (tab->getJoystick() == joystick))
         {
-            tabBar()->setTabTextColor(i, Qt::black);
+            tabBar()->setTabTextColor(i, QApplication::palette().color(QPalette::Text));
             found = true;
         }
     }
@@ -84,7 +84,7 @@ void JoyTabWidgetContainer::unflashTab(JoyTabWidget *tabWidget)
         JoyTabWidget *tab = qobject_cast<JoyTabWidget *>(widget(i)); // static_cast
         if (tab == tabWidget)
         {
-            tabBar()->setTabTextColor(i, Qt::black);
+            tabBar()->setTabTextColor(i, QApplication::palette().color(QPalette::Text));
         }
     }
 }
@@ -96,7 +96,7 @@ void JoyTabWidgetContainer::unflashAll()
         JoyTabWidget *tab = qobject_cast<JoyTabWidget *>(widget(i)); // static_cast
         if (tab != nullptr)
         {
-            tabBar()->setTabTextColor(i, Qt::black);
+            tabBar()->setTabTextColor(i, QApplication::palette().color(QPalette::Text));
         }
     }
 }


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/45544416/197865366-0c7b2fdf-7a23-4b96-a96a-035551d235b2.png)
