### PR TITLE
Fix __BIG_ENDIAN constant

### DIFF
--- a/src/haptictriggerps5.cpp
+++ b/src/haptictriggerps5.cpp
@@ -27,7 +27,7 @@ constexpr u16 u16tole(u16 x)
 {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return x;
-#elif __BYTE_ORDER == _BIG_ENDIAN
+#elif __BYTE_ORDER == __BIG_ENDIAN
     return ((x << 8) & 0xFF00) | ((x >> 8) & 0x00FF);
 #else
     #error "Target machine has unknown endianness!"
@@ -38,7 +38,7 @@ constexpr u32 u32tole(u32 x)
 {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return x;
-#elif __BYTE_ORDER == _BIG_ENDIAN
+#elif __BYTE_ORDER == __BIG_ENDIAN
     return ((x << 24) & 0xFF000000) | ((x << 8) & 0x00FF0000) | ((x >> 8) & 0x0000FF00) | ((x >> 24) & 0x000000FF);
 #else
     #error "Target machine has unknown endianness!"


### PR DESCRIPTION
## Proposed changes 

- Failed to build on Fedora s390x arch, because it's big-endian - PR fixes constant as defined in glibc [`endian.h`](https://sourceware.org/git/?p=glibc.git;a=blob;f=string/endian.h;h=f91984686103d71b5bf499077d8eac4a0e0184c6;hb=HEAD#l28)

(No need for a new release just for this, I'm adding a package patch until then.)

----


<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

