### PR TITLE
chore: Disable automatic window hide

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -979,7 +979,9 @@ void MainWindow::changeEvent(QEvent *event)
             bool minimizeToTaskbar = m_settings->value("MinimizeToTaskbar", false).toBool();
             if (QSystemTrayIcon::isSystemTrayAvailable() && showTrayIcon && !minimizeToTaskbar)
             {
+#ifndef Q_OS_UNIX
                 this->hideWindow();
+#endif
             } else
             {
                 disableFlashActions();


### PR DESCRIPTION
Disable change introduced in https://github.com/AntiMicroX/antimicrox/commit/7a6e3b2add50f43d9c64531aa364e7ffc5978dc8 and in https://github.com/AntiMicroX/antimicrox/commit/5c99050ccd204d899eb150eb6ff4503264712001

Because of this app automatically minimized window even when it was not necessary (switching workspaces on Linux)