### PR TITLE
fix: Print system config in logs second time for Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -560,10 +560,11 @@ int main(int argc, char *argv[])
 #endif
         delete appLogger;
         return EXIT_FAILURE;
-    } else
-    {
-        qInfo() << QObject::tr("Using %1 as the event generator.").arg(factory->handler()->getName());
     }
+    qInfo() << QObject::tr("Using %1 as the event generator.").arg(factory->handler()->getName());
+#ifdef Q_OS_WIN
+    log_system_config(); // workaround for missing windows logs
+#endif
 
     PadderCommon::mouseHelperObj.initDeskWid();
     QPointer<InputDaemon> joypad_worker = new InputDaemon(joysticks, &settings);


### PR DESCRIPTION
In case of Windows builds we may lose several first logs, the ones containing system config are among them. To mitigate this problem I added printing second logs second time. (regular sleep on main thread to tel logger initialize did not help)