### PR TITLE
chore(msvc): add msvc cmake support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,6 +5,7 @@ Most of these packages are already built and available on [Release Page](https:/
 - [Building AntiMicroX](#building-antimicrox)
   - [Build Dependencies](#build-dependencies)
   - [Basic building](#basic-building)
+    - [MSVC building tips](#msvc-building-tips)
     - [Build Options for CMake](#build-options-for-cmake)
     - [Universal Options](#universal-options)
     - [Linux Options](#linux-options)
@@ -57,7 +58,7 @@ sudo apt install g++ cmake extra-cmake-modules qttools5-dev qttools5-dev-tools l
   <summary>Windows dependencies</summary>
 In case of Windows you need QT, SDL2 libraries, cmake and compiler (mingw for example).
 
-For setting up your environment you may use `msys2`.
+For setting up your environment you may use `msys2`. Alternatively, you may use `MSVC`.
 
 </details>
 
@@ -88,6 +89,16 @@ Run built binaries
 ```
 ./bin/antimicrox
 ```
+
+#### MSVC building tips
+
+Recent versions of Visual Studio (2017+) have support for cmake projects. Under Visual Studio 2022, building AntiMicroX is quite straight forward.
+- Ensure you have compatable versions of [Qt](https://www.qt.io/download) (5.9 works as of writing,) and [SDL2-devel](https://github.com/libsdl-org/SDL/releases/) installed.
+- Open antimicrox as a local folder in VS22. It should pick up the `CMakeLists.txt` and offer an option to open the CMake settings editor. If it doesn't, right click on `CMakeLists.txt` in the solution explorer and select `CMake settings for antimicrox`.
+- In the `Command arguments` section, add an argument to tell CMake where to find your Qt; E.g.: `"-DCMAKE_PREFIX_PATH=C:\Qt\5.9\msvc2017_64\lib\cmake"`. As of writing, Qt's msvc2017 works properly through vs22.
+- Under the `Cmake variables and cache` section, click the link labeled `Save and generate cmake cache to load variables.
+- If the CMake generation fails due to SDL2, find the variables named `SDL2_PATH`, `SDL2_INCLUDE_DIR`, and `SDL2_DLL_LOCATION_DIR` in the list view, and set them properly. You may also need to move the headers in the SDL2 include dir inside a folder named `SDL2` to match their include paths on other systems.
+- At this point you should be able to save your changes to regenerate the cmake cache, which will then allow you to build `antimicrox.exe` through Visual Studio.
 
 A recommended way of installation is building package typical for for your system (or building universal one like an AppImage).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,22 @@ endif(UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND MSVC_TOOLSET_VERSION GREATER_EQUAL 140)
+    # MSVC tools v140 and later support c++11 ootb and has no flag to enable it.
+    set(COMPILER_SUPPORTS_CXX11 1)
+    set(COMPILER_IS_MSVC 1)
+else()
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+endif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND MSVC_TOOLSET_VERSION GREATER_EQUAL 140)
 
 
-if(COMPILER_SUPPORTS_CXX11)
-    message("Build type: ${CMAKE_BUILD_TYPE}")
+if(NOT COMPILER_SUPPORTS_CXX11)
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif(NOT COMPILER_SUPPORTS_CXX11)
+
+message("Build type: ${CMAKE_BUILD_TYPE}")
+
+if(NOT COMPILER_IS_MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -O0 -fno-omit-frame-pointer")
     if(UNIX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -50,8 +61,13 @@ if(COMPILER_SUPPORTS_CXX11)
     endif(UNIX AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wstrict-null-sentinel -Wstrict-overflow=5 -Wundef -Wno-unused -std=c++11")
 else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /analyze- /D_CRT_SECURE_NO_WARNINGS")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /GS /Od /sdl /RTC1 /Gd /Oy-")
+    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 141)
+        # VS2017 (toolset v141) and later can set /permissive- to disable non-standard conforming behavior
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /permissive-")
+    endif(MSVC_TOOLSET_VERSION GREATER_EQUAL 141)
+endif(NOT COMPILER_IS_MSVC)
 
 # The version number.
 set(ANTIMICROX_MAJOR_VERSION 3)

--- a/src/eventhandlers/winsendinputeventhandler.cpp
+++ b/src/eventhandlers/winsendinputeventhandler.cpp
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QVarLengthArray>
 #include <cmath>
 #include <qt_windows.h>
 
@@ -165,9 +166,11 @@ void WinSendInputEventHandler::sendTextEntryEvent(QString maintext)
 
             tempList.append(temp.virtualkey);
 
-            if (tempList.size() > 0)
+            int inputCount = tempList.size();
+
+            if (inputCount > 0)
             {
-                INPUT tempBuffer[tempList.size()] = {0};
+                QVarLengthArray<INPUT> tempBuffer(inputCount);
 
                 unsigned int j = 0;
                 for (auto iter = tempList.cbegin(); iter != tempList.cend(); ++iter, ++j)
@@ -186,10 +189,10 @@ void WinSendInputEventHandler::sendTextEntryEvent(QString maintext)
                     tempBuffer[j].ki.dwFlags = tempflags;
                 }
 
-                SendInput(j, tempBuffer, sizeof(INPUT));
+                SendInput(j, tempBuffer.data(), sizeof(INPUT));
 
                 j = 0;
-                memset(tempBuffer, 0, sizeof(tempBuffer));
+                memset(tempBuffer.data(), 0, sizeof(INPUT) * inputCount);
                 // INPUT tempBuffer2[tempList.size()] = {0};
                 for (auto iter = tempList.crbegin(); iter != tempList.crend(); ++iter, ++j)
                 {
@@ -207,7 +210,7 @@ void WinSendInputEventHandler::sendTextEntryEvent(QString maintext)
                     tempBuffer[j].ki.dwFlags = tempflags | KEYEVENTF_KEYUP;
                 }
 
-                SendInput(j, tempBuffer, sizeof(INPUT));
+                SendInput(j, tempBuffer.data(), sizeof(INPUT));
             }
         }
     }

--- a/src/inputdaemon.cpp
+++ b/src/inputdaemon.cpp
@@ -1175,7 +1175,7 @@ void InputDaemon::secondInputPass(QQueue<SDL_Event> *sdlEventQueue)
             if (joy != nullptr)
             {
                 SetJoystick *set = joy->getActiveSetJoystick();
-                JoySensor *sensor;
+                JoySensor *sensor = nullptr;
                 if (event.csensor.sensor == SDL_SENSOR_ACCEL)
                     sensor = set->getSensor(ACCELEROMETER);
                 else if (event.csensor.sensor == SDL_SENSOR_GYRO)


### PR DESCRIPTION
Just two small changes and some `CMakeLists.txt` additions is all it took to build through Visual Studio 2022.

C&C welcome!

## Proposed changes 

- Initializes a "potentially uninitialized" pointer that msvc whines about due to `/sdl`.
- Replaces a VLA with a `QVarLengthArray` since msvc doesn't support all of C99.
- Adds a check for msvc to `CMakeLists.txt`, and sets compiler flags that closely match the existing gcc/clang counterparts.
- Adds a few lines to `BUILDING.md` to elaborate on how to use Visual Studio's built-in cmake support to compile the project.

----

A screenshot quite unlikely needed for this, but I took one anyways 😂

![image](https://user-images.githubusercontent.com/602691/208269659-d9e93717-c134-4768-9df4-415242352092.png)

Fixes the msvc warning as error due to `/sdl`.Fixes the msvc warning as error due to `/sdl`.Fixes the msvc warning as error due to `/sdl`.Fixes the msvc warning as error due to `/sdl`.