### PR TITLE
refactor: Fix reorder compile warning

### DIFF
--- a/src/gui/joytabwidget.cpp
+++ b/src/gui/joytabwidget.cpp
@@ -71,9 +71,9 @@ bool JoyTabWidget::changedNotSaved = false;
 
 JoyTabWidget::JoyTabWidget(InputDevice *joystick, AntiMicroSettings *settings, QWidget *parent)
     : QWidget(parent)
-    , tabHelper(joystick)
     , m_joystick(joystick)
     , m_settings(settings)
+    , tabHelper(joystick)
 {
     tabHelper.moveToThread(joystick->thread());
 

--- a/src/joybuttonslot.cpp
+++ b/src/joybuttonslot.cpp
@@ -58,8 +58,8 @@ JoyButtonSlot::JoyButtonSlot(int code, int alias, JoySlotInputAction mode, QObje
 
 JoyButtonSlot::JoyButtonSlot(JoyButtonSlot *slot, QObject *parent)
     : QObject(parent)
-    , extraData()
     , mix_slots(nullptr)
+    , extraData()
 {
     copyAssignments(*slot);
 }


### PR DESCRIPTION
```
In file included from /home/runner/work/antimicrox/antimicrox/src/gui/joytabwidget.cpp:19:
/home/runner/work/antimicrox/antimicrox/src/gui/joytabwidget.h: In constructor ‘JoyTabWidget::JoyTabWidget(InputDevice*, AntiMicroSettings*, QWidget*)’:
/home/runner/work/antimicrox/antimicrox/src/gui/joytabwidget.h:227:24: warning: ‘JoyTabWidget::tabHelper’ will be initialized after [-Wreorder]
  227 |     JoyTabWidgetHelper tabHelper;
      |                        ^~~~~~~~~
/home/runner/work/antimicrox/antimicrox/src/gui/joytabwidget.h:219:18: warning:   ‘InputDevice* JoyTabWidget::m_joystick’ [-Wreorder]
  219 |     InputDevice *m_joystick;
      |                  ^~~~~~~~~~
/home/runner/work/antimicrox/antimicrox/src/gui/joytabwidget.cpp:72:1: warning:   when initialized here [-Wreorder]
   72 | JoyTabWidget::JoyTabWidget(InputDevice *joystick, AntiMicroSettings *settings, QWidget *parent)
      | ^~~~~~~~~~~~
```

```
 /home/runner/work/antimicrox/antimicrox/src/joybuttonslot.h: In constructor ‘JoyButtonSlot::JoyButtonSlot(JoyButtonSlot*, QObject*)’:
/home/runner/work/antimicrox/antimicrox/src/joybuttonslot.h:150:14: warning: ‘JoyButtonSlot::extraData’ will be initialized after [-Wreorder]
  150 |     QVariant extraData;
      |              ^~~~~~~~~
/home/runner/work/antimicrox/antimicrox/src/joybuttonslot.h:143:29: warning:   ‘QList<JoyButtonSlot*>* JoyButtonSlot::mix_slots’ [-Wreorder]
  143 |     QList<JoyButtonSlot *> *mix_slots;
      |                             ^~~~~~~~~
/home/runner/work/antimicrox/antimicrox/src/joybuttonslot.cpp:59:1: warning:   when initialized here [-Wreorder]
   59 | JoyButtonSlot::JoyButtonSlot(JoyButtonSlot *slot, QObject *parent)
      | ^~~~~~~~~~~~~
```