### PR TITLE
fix: Super_L virtual keyboard map to KEY_LEFTMETA

### DIFF
--- a/src/uinputhelper.cpp
+++ b/src/uinputhelper.cpp
@@ -124,7 +124,7 @@ void UInputHelper::populateX11SymVk(QHash<QString, int> &knownAliasesX11SymVK)
     knownAliasesX11SymVK.insert("period", KEY_DOT);
     knownAliasesX11SymVK.insert("slash", KEY_SLASH);
     knownAliasesX11SymVK.insert("Control_L", KEY_LEFTCTRL);
-    knownAliasesX11SymVK.insert("Super_L", KEY_MENU);
+    knownAliasesX11SymVK.insert("Super_L", KEY_LEFTMETA);
     knownAliasesX11SymVK.insert("Alt_L", KEY_LEFTALT);
     knownAliasesX11SymVK.insert("space", KEY_SPACE);
     knownAliasesX11SymVK.insert("Alt_R", KEY_RIGHTALT);


### PR DESCRIPTION
Super_L is honored as KEY_LEFTMETA in GUI environments. (keycode 125)
Issue #749 

Closes #749 



<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

