### PR TITLE
chore: Switch building AppImage build to Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,18 +26,18 @@ jobs:
                       cxx: g++
                       build-type: Debug
                       experimental: false
+                    - name: Ubuntu 22-04 Clang
+                      image: ubuntu-22.04
+                      cc: clang
+                      cxx: clang++
+                      build-type: Debug
+                      experimental: true
                     - name: Ubuntu 20-04 GCC  (for AppImage comp)
                       image: ubuntu-20.04
                       cc: gcc
                       cxx: g++
                       build-type: Debug
                       experimental: false
-                    - name: Ubuntu 20-04 Clang
-                      image: ubuntu-20.04
-                      cc: clang
-                      cxx: clang++
-                      build-type: Debug
-                      experimental: true
 
         name: ${{ matrix.name }} ${{ matrix.build-type }}
         runs-on: ${{ matrix.image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
                       cxx: g++
                       build-type: Debug
                       experimental: false
-                    - name: Ubuntu 20-04 GCC
+                    - name: Ubuntu 20-04 GCC  (for AppImage comp)
                       image: ubuntu-20.04
                       cc: gcc
                       cxx: g++
@@ -38,12 +38,6 @@ jobs:
                       cxx: clang++
                       build-type: Debug
                       experimental: true
-                    - name: Ubuntu 18-04 GCC (for AppImage comp)
-                      image: ubuntu-18.04
-                      cc: gcc
-                      cxx: g++
-                      build-type: Release
-                      experimental: false
 
         name: ${{ matrix.name }} ${{ matrix.build-type }}
         runs-on: ${{ matrix.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     build-appimage:
         # Version of ubuntu building this appimage, it shouldn't be the latest verion of ubuntu to avoid breaking compatibility with older systems
         name: Build AppImage package
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
 
         steps:
 


### PR DESCRIPTION
18.04 Is deprecated now and GitHub runners are disabled

LInked issue https://github.com/actions/runner-images/issues/6002