### PR TITLE
fix: Change sdl version macro to match version od introduction

### DIFF
--- a/src/inputdevice.h
+++ b/src/inputdevice.h
@@ -32,7 +32,7 @@ class QXmlStreamReader;
 class QXmlStreamWriter;
 class QSettings;
 
-#if not SDL_VERSION_ATLEAST(2, 0, 16)
+#if not SDL_VERSION_ATLEAST(2, 0, 12)
 enum SDL_GameControllerType
 {
     SDL_CONTROLLER_TYPE_UNKNOWN = 0


### PR DESCRIPTION
Closes: https://github.com/AntiMicroX/antimicrox/issues/788