### PR TITLE
chore: bump SDL version to 2.28.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,15 +100,15 @@ jobs:
             - name: Install sdl2 (mingw-w64)
               if: startsWith(matrix.shell, 'msys2')
               run: |
-                curl -L -o mingw-w64-x86_64-SDL2-2.28.0-1-any.pkg.tar.zst https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-SDL2-2.28.0-1-any.pkg.tar.zst
-                pacman --noconfirm -U mingw-w64-x86_64-SDL2-2.28.0-1-any.pkg.tar.zst
+                curl -L -o mingw-w64-x86_64-SDL2-2.28.2-1-any.pkg.tar.zst https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-SDL2-2.28.2-1-any.pkg.tar.zst
+                pacman --noconfirm -U mingw-w64-x86_64-SDL2-2.28.2-1-any.pkg.tar.zst
             
             - name: Install sdl2 (msvc)
               if: startsWith(matrix.shell, 'cmd')
               run: |
-                curl -L -o SDL2-devel-2.0.20-VC.zip https://github.com/libsdl-org/SDL/releases/download/release-2.0.20/SDL2-devel-2.0.20-VC.zip
-                unzip SDL2-devel-2.0.20-VC.zip
-                mv "${{ github.workspace }}/SDL2-2.0.20" "${{ github.workspace }}/sdl2"
+                curl -L -o SDL2-devel-2.28.2-VC.zip https://github.com/libsdl-org/SDL/releases/download/release-2.28.2/SDL2-devel-2.28.2-VC.zip
+                unzip SDL2-devel-2.28.2-VC.zip
+                mv "${{ github.workspace }}/SDL2-2.28.2" "${{ github.workspace }}/sdl2"
                 mklink /J "${{ github.workspace }}\sdl2\SDL2" "${{ github.workspace }}\sdl2\include"
               
             - name: Install MSVC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
             #Replace original library with the newer one
             - name: Build and install newer SDL2
               run: |
-                git clone https://github.com/libsdl-org/SDL.git -b release-2.26.5
+                git clone https://github.com/libsdl-org/SDL.git -b release-2.28.2
                 cd SDL
                 mkdir build
                 cd build
@@ -154,8 +154,8 @@ jobs:
             # SDL2 version for release locked
             - name: Install sdl2
               run: |
-                curl -L -o mingw-w64-x86_64-SDL2-2.28.0-1-any.pkg.tar.zst https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-SDL2-2.28.0-1-any.pkg.tar.zst
-                pacman --noconfirm -U mingw-w64-x86_64-SDL2-2.28.0-1-any.pkg.tar.zst
+                curl -L -o mingw-w64-x86_64-SDL2-2.28.2-1-any.pkg.tar.zst https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-SDL2-2.28.2-1-any.pkg.tar.zst
+                pacman --noconfirm -U mingw-w64-x86_64-SDL2-2.28.2-1-any.pkg.tar.zst
 
             - name: Install Qt
               uses: jurplel/install-qt-action@v3


### PR DESCRIPTION
Bump SDL version  to the latest one (2.28.2) https://github.com/libsdl-org/SDL/releases/tag/release-2.28.2