### PR TITLE
Rewrite code using QDesktopWidget Class

### DIFF
--- a/src/applaunchhelper.cpp
+++ b/src/applaunchhelper.cpp
@@ -24,7 +24,6 @@
 #include "joybuttontypes/joybutton.h"
 
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QMapIterator>
 #include <QThread>
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -316,7 +316,8 @@ void sendSpringEvent(PadderCommon::springModeInfo *fullSpring, PadderCommon::spr
             fullSpring->screen = -1;
         }
 
-        QRect deskRect = QGuiApplication::screens().at(fullSpring->screen)->geometry();
+        QRect deskRect = fullSpring->screen == -1 ? QGuiApplication::primaryScreen()->geometry()
+                                                  : QGuiApplication::screens().at(fullSpring->screen)->geometry();
 
         width = deskRect.width();
         height = deskRect.height();

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -20,7 +20,6 @@
 #include <QApplication>
 #include <QCursor>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QProcess>

--- a/src/gui/mainsettingsdialog.cpp
+++ b/src/gui/mainsettingsdialog.cpp
@@ -39,7 +39,6 @@
 #include <QApplication>
 #include <QComboBox>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QDir>
 #include <QFileDialog>
 #include <QLabel>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -548,7 +548,6 @@ int main(int argc, char *argv[])
     PadderCommon::log_system_config(); // workaround for missing windows logs
 #endif
 
-    PadderCommon::mouseHelperObj.initDeskWid();
     QPointer<InputDaemon> joypad_worker = new InputDaemon(joysticks, &settings);
     inputEventThread = new QThread();
     inputEventThread->setObjectName("inputEventThread");
@@ -570,8 +569,6 @@ int main(int argc, char *argv[])
     QObject::connect(&antimicrox, &QApplication::aboutToQuit, &mainAppHelper, &AppLaunchHelper::revertMouseThread);
     QObject::connect(&antimicrox, &QApplication::aboutToQuit, joypad_worker.data(), &InputDaemon::quit);
     QObject::connect(&antimicrox, &QApplication::aboutToQuit, joypad_worker.data(), &InputDaemon::deleteLater);
-    QObject::connect(&antimicrox, &QApplication::aboutToQuit, &PadderCommon::mouseHelperObj, &MouseHelper::deleteDeskWid,
-                     Qt::DirectConnection);
 
     QObject::connect(localServer, &LocalAntiMicroServer::showHiddenWindow, mainWindow, &MainWindow::show);
     QObject::connect(localServer, &LocalAntiMicroServer::clientdisconnect, mainWindow,

--- a/src/mousedialog/springmoderegionpreview.cpp
+++ b/src/mousedialog/springmoderegionpreview.cpp
@@ -20,9 +20,9 @@
 
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QScreen>
 
 SpringModeRegionPreview::SpringModeRegionPreview(int width, int height, QWidget *parent)
     :
@@ -43,8 +43,9 @@ SpringModeRegionPreview::SpringModeRegionPreview(int width, int height, QWidget 
 
     if ((tempwidth >= 2) && (tempheight >= 2))
     {
-        int cw = (qApp->desktop()->width() / 2) - (tempwidth / 2);
-        int ch = (qApp->desktop()->height() / 2) - (tempheight / 2);
+        // TODO create a simple class representing display fopr calculating cursor locations
+        int cw = (QGuiApplication::primaryScreen()->virtualGeometry().width() / 2) - (tempwidth / 2);
+        int ch = (QGuiApplication::primaryScreen()->virtualGeometry().height() / 2) - (tempheight / 2);
 
         setGeometry(cw, ch, tempwidth, tempheight);
         show();
@@ -108,8 +109,8 @@ void SpringModeRegionPreview::setSpringWidth(int width)
 
     if ((tempwidth >= 2) && (height >= 2))
     {
-        int cw = (qApp->desktop()->width() / 2) - (tempwidth / 2);
-        int ch = (qApp->desktop()->height() / 2) - (height / 2);
+        int cw = (QGuiApplication::primaryScreen()->virtualGeometry().width() / 2) - (tempwidth / 2);
+        int ch = (QGuiApplication::primaryScreen()->virtualGeometry().height() / 2) - (height / 2);
 
         setGeometry(cw, ch, tempwidth, height);
         if (!isVisible())
@@ -133,8 +134,8 @@ void SpringModeRegionPreview::setSpringHeight(int height)
 
     if ((width >= 2) && (tempheight >= 2))
     {
-        int cw = (qApp->desktop()->width() / 2) - (width / 2);
-        int ch = (qApp->desktop()->height() / 2) - (tempheight / 2);
+        int cw = (QGuiApplication::primaryScreen()->virtualGeometry().width() / 2) - (width / 2);
+        int ch = (QGuiApplication::primaryScreen()->virtualGeometry().height() / 2) - (tempheight / 2);
 
         setGeometry(cw, ch, width, tempheight);
         if (!isVisible())
@@ -153,8 +154,8 @@ void SpringModeRegionPreview::setSpringSize(int width, int height)
     int tempwidth = adjustSpringSizeWidth(width);
     int tempheight = adjustSpringSizeHeight(height);
 
-    int cw = (qApp->desktop()->width() / 2) - (tempwidth / 2);
-    int ch = (qApp->desktop()->height() / 2) - (height / 2);
+    int cw = (QGuiApplication::primaryScreen()->virtualGeometry().width() / 2) - (tempwidth / 2);
+    int ch = (QGuiApplication::primaryScreen()->virtualGeometry().height() / 2) - (height / 2);
 
     resize(tempwidth, tempheight);
     move(cw, ch);

--- a/src/mousehelper.cpp
+++ b/src/mousehelper.cpp
@@ -19,7 +19,6 @@
 #include "mousehelper.h"
 
 #include <QDebug>
-#include <QDesktopWidget>
 
 MouseHelper::MouseHelper(QObject *parent)
     : QObject(parent)
@@ -35,20 +34,3 @@ MouseHelper::MouseHelper(QObject *parent)
 }
 
 void MouseHelper::resetSpringMouseMoving() { springMouseMoving = false; }
-
-void MouseHelper::initDeskWid()
-{
-    if (deskWid == nullptr)
-        deskWid = new QDesktopWidget;
-}
-
-void MouseHelper::deleteDeskWid()
-{
-    if (deskWid != nullptr)
-    {
-        delete deskWid;
-        deskWid = nullptr;
-    }
-}
-
-QDesktopWidget *MouseHelper::getDesktopWidget() const { return deskWid; }

--- a/src/mousehelper.h
+++ b/src/mousehelper.h
@@ -22,29 +22,19 @@
 #include <QObject>
 #include <QTimer>
 
-class QDesktopWidget;
-
 class MouseHelper : public QObject
 {
     Q_OBJECT
 
   public:
     explicit MouseHelper(QObject *parent = nullptr);
-    QDesktopWidget *getDesktopWidget() const;
     bool springMouseMoving;
     int previousCursorLocation[2];
     int pivotPoint[2];
     QTimer mouseTimer;
 
-  public slots:
-    void deleteDeskWid();
-    void initDeskWid();
-
   private slots:
     void resetSpringMouseMoving();
-
-  private:
-    QDesktopWidget *deskWid;
 };
 
 #endif // MOUSEHELPER_H

--- a/src/springmousemoveinfo.h
+++ b/src/springmousemoveinfo.h
@@ -33,7 +33,7 @@ typedef struct _springModeInfo
     // Should the cursor not move around the center
     // of the screen.
     bool relative;
-    int screen;
+    int screen; //-1 for default screen
     double springDeadX;
     double springDeadY;
 


### PR DESCRIPTION
Linked with: #446 

Rewrite code which used QDesktopWidget Class, because it is deprecated [link](https://doc.qt.io/qt-6/widgets-changes-qt6.html#qdesktopwidget-and-qapplication-desktop) 