### PR TITLE
Set StartupWMClass in Linux desktop launcher.

### DIFF
--- a/other/io.github.antimicrox.antimicrox.desktop
+++ b/other/io.github.antimicrox.antimicrox.desktop
@@ -17,6 +17,7 @@ Categories=Qt;Utility;
 MimeType=application/x-amgp;
 Keywords=game;controller;keyboard;joystick;mouse;
 Actions=run-in-tray;
+StartupWMClass=antimicrox
 
 [Desktop Action run-in-tray]
 Name=Open in system tray only


### PR DESCRIPTION
This keeps the window attached to a pinned launcher, preventing things like this: 
![antimicrox-launcher](https://github.com/AntiMicroX/antimicrox/assets/36964161/b40092dd-466b-4be0-822e-48a4835a5797)


