### PR TITLE
fix: Fixing builds with X11=OFF

### DIFF
--- a/src/gui/addeditautoprofiledialog.cpp
+++ b/src/gui/addeditautoprofiledialog.cpp
@@ -328,7 +328,6 @@ void AddEditAutoProfileDialog::checkForGrabbedWindow(UnixCaptureWindowUtility *u
 
         util->deleteLater();
     }
-
     #endif
 }
 #endif
@@ -339,32 +338,29 @@ void AddEditAutoProfileDialog::windowPropAssignment(CapturedWindowInfoDialog *di
     disconnect(ui->winClassLineEdit, &QLineEdit::textChanged, this, &AddEditAutoProfileDialog::checkForDefaultStatus);
     disconnect(ui->winNameLineEdit, &QLineEdit::textChanged, this, &AddEditAutoProfileDialog::checkForDefaultStatus);
 
+    ui->applicationLineEdit->clear();
+    ui->winClassLineEdit->clear();
+    ui->winNameLineEdit->clear();
+
+#ifdef WITH_X11
     if (dialog->useFullWindowPath() && dialog->getSelectedOptions() & CapturedWindowInfoDialog::WindowPath)
     {
         ui->applicationLineEdit->setText(dialog->getWindowPath());
     } else if (!dialog->useFullWindowPath() && dialog->getSelectedOptions() & CapturedWindowInfoDialog::WindowPath)
     {
         ui->applicationLineEdit->setText(QFileInfo(dialog->getWindowPath()).fileName());
-    } else
-    {
-        ui->applicationLineEdit->clear();
     }
 
     if (dialog->getSelectedOptions() & CapturedWindowInfoDialog::WindowClass)
     {
         ui->winClassLineEdit->setText(dialog->getWindowClass());
-    } else
-    {
-        ui->winClassLineEdit->clear();
     }
 
     if (dialog->getSelectedOptions() & CapturedWindowInfoDialog::WindowName)
     {
         ui->winNameLineEdit->setText(dialog->getWindowName());
-    } else
-    {
-        ui->winNameLineEdit->clear();
     }
+#endif
 
     checkForDefaultStatus();
 

--- a/src/gui/buttoneditdialog.cpp
+++ b/src/gui/buttoneditdialog.cpp
@@ -264,8 +264,8 @@ void ButtonEditDialog::keyReleaseEvent(QKeyEvent *event)
         }
 
     #else
-        int finalvirtual = 0;
-        int checkalias = 0;
+        finalvirtual = 0;
+        checkalias = 0;
         if (QApplication::platformName() == QStringLiteral("xcb"))
         {
             finalvirtual = AntKeyMapper::getInstance()->returnVirtualKey(event->key());


### PR DESCRIPTION
The code does not compile when building with `X11=OFF`: 
```
cd antimicrox
mkdir build && cd build
cmake -DWITH_X11=OFF ..  # Fails!
cmake --build .
```

There are errors in two files that cause this.
* In `src/gui/addeditautoprofiledialog.cpp`, the code attempts to call functions of `dialog` that are not present.
* In `src/gui/buttoneditdialog.cpp`, there are two variables that have already been defined, which causes the compilation to fail.


This PR makes the code compile again.

<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

