### PR TITLE
chore: Ensure proper type for storing unicode

### DIFF
--- a/src/qtuinputkeymapper.cpp
+++ b/src/qtuinputkeymapper.cpp
@@ -181,14 +181,14 @@ void QtUInputKeyMapper::populateCharKeyInformation()
 {
     virtkeyToCharKeyInfo.clear();
 
-    int unicodeTempValue = 0;
+    char16_t unicodeTempValue = 0;
     int listIndex = 0;
     charKeyInformation charKeyInfo;
     charKeyInfo.modifiers = Qt::NoModifier;
     charKeyInfo.virtualkey = 0;
 
     // Map 0-9 keys
-    for (int i = QChar('1').unicode(); i <= QChar('9').unicode(); i++)
+    for (char16_t i = QChar('1').unicode(); i <= QChar('9').unicode(); i++)
         addVirtualKeyToHash(KEY_1 + i, i, charKeyInfo);
 
     addVirtualKeyToHash(KEY_0, QChar('0'), charKeyInfo);
@@ -264,7 +264,7 @@ void QtUInputKeyMapper::populateCharKeyInformation()
 
     while (tempIter.hasNext())
     {
-        addVirtualKeyToHash(KEY_1 + listIndex, tempIter.next(), charKeyInfo);
+        addVirtualKeyToHash(KEY_1 + listIndex, QChar(tempIter.next()), charKeyInfo);
         listIndex++;
     }
 

--- a/src/xmlconfigmigration.cpp
+++ b/src/xmlconfigmigration.cpp
@@ -103,7 +103,7 @@ QString XMLConfigMigration::version0006Migration()
 
     while (!reader->atEnd())
     {
-        if ((reader->name() == "slot") && reader->isStartElement())
+        if ((reader->name() == u"slot") && reader->isStartElement())
         {
             int slotcode = 0;
             QString slotmode = QString();
@@ -111,13 +111,13 @@ QString XMLConfigMigration::version0006Migration()
             reader->readNext();
 
             // Grab current slot code and slot mode
-            while (!reader->atEnd() && (!reader->isEndElement() && (reader->name() != "slot")))
+            while (!reader->atEnd() && (!reader->isEndElement() && (reader->name() != u"slot")))
             {
-                if ((reader->name() == "code") && reader->isStartElement())
+                if ((reader->name() == u"code") && reader->isStartElement())
                 {
                     QString tempcode = reader->readElementText();
                     slotcode = tempcode.toInt();
-                } else if ((reader->name() == "mode") && reader->isStartElement())
+                } else if ((reader->name() == u"mode") && reader->isStartElement())
                 {
                     slotmode = reader->readElementText();
                 } else


### PR DESCRIPTION
`QChar.unicode()` returns type: `char16_t`
https://doc.qt.io/qt-6/qchar.html#unicode