### PR TITLE
rest accel. while changing set, fix #991

### DIFF
--- a/src/joyaccelerometersensor.cpp
+++ b/src/joyaccelerometersensor.cpp
@@ -185,6 +185,11 @@ JoySensorDirection JoyAccelerometerSensor::calculateSensorDirection()
     bool inPitch = pitch_abs < m_dead_zone;
     bool inRoll = roll_abs < range;
 
+    if (isnan(roll))
+    {
+        return SENSOR_CENTERED;
+    }
+
     if (!inPitch)
     {
         if (!inRoll)


### PR DESCRIPTION
Closes #991. When we change sets, both roll and pitch become NaN. We avoid comparing NaN values with numbers that in turn can trigger or not depending on compiler.