### PR TITLE
fix: button 6 is wheel left; button 7 is wheel right

### DIFF
--- a/src/eventhandlers/uinputeventhandler.cpp
+++ b/src/eventhandlers/uinputeventhandler.cpp
@@ -233,13 +233,13 @@ void UInputEventHandler::sendMouseButtonEvent(JoyButtonSlot *slot, bool pressed)
         {
             if (pressed)
             {
-                write_uinput_event(mouseFileHandler, EV_REL, REL_HWHEEL, 1);
+                write_uinput_event(mouseFileHandler, EV_REL, REL_HWHEEL, -1);
             }
         } else if (code == 7)
         {
             if (pressed)
             {
-                write_uinput_event(mouseFileHandler, EV_REL, REL_HWHEEL, -1);
+                write_uinput_event(mouseFileHandler, EV_REL, REL_HWHEEL, 1);
             }
         } else if (code == 8)
         {


### PR DESCRIPTION
## Proposed changes 

- The binding labeled ‘Wheel Left’ in the GUI corresponds to mouse button 6, as seen in `src/joybuttonslot.h`. This should send a negative `REL_HWHEEL` event to uinput.
- Ditto for ‘Wheel Right’, button 7, positive `REL_HWHEEL`

----


<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, wih screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

