### PR TITLE
Cleanup in deb dependencies, use QT6 in Ubuntu 24.04 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,13 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Install Dependencies
+            - name: Install Dependencies with QT5
+              if: matrix.image != 'ubuntu-24.04'
               run: sudo apt-get update && sudo apt-get install extra-cmake-modules qttools5-dev qttools5-dev-tools libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext
+
+            - name: Install Dependencies with QT6
+              if: matrix.image == 'ubuntu-24.04'
+              run: sudo apt-get update && sudo apt-get install extra-cmake-modules qt6-base-dev qt6-tools-dev-tools libqt6core5compat6-dev qt6-tools-dev libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext
 
             - name: Configure CMake
               run: cmake -DCPACK_GENERATOR="DEB" -DCMAKE_BUILD_TYPE=Release -DCHECK_FOR_UPDATES=ON -DANTIMICROX_PKG_VERSION="GitHub deb Release" -B ${{ github.workspace }}/build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,7 +25,7 @@ installed on your system in order to build this program:
 - `cmake`
 - `extra-cmake-modules`
 - QT libraries:
-  - For QT6: `qt6-base-dev`, `qt6-tools-dev-tools` `libqt6core5compat6-dev`
+  - For QT6: `qt6-base-dev`, `qt6-tools-dev-tools` `libqt6core5compat6-dev` `qt6-tools-dev`
   - For QT5: `qttools5-dev` and `qttools5-dev-tools` (`qt5-tools` on distros based on Arch Linux)
 - `libsdl2-dev` (`sdl2` on distros based on Arch Linux) (SDL2)
 - `libxi-dev` (`libxi` on distros based on Arch Linux) (Optional. Needed to compile with X11 and uinput support)
@@ -51,7 +51,7 @@ sudo dnf install git make cmake gcc cmake extra-cmake-modules qt6-qttools-devel 
 One-liner for installing above dependencies:  
 
 ```bash
-sudo apt install g++ cmake extra-cmake-modules qt6-base-dev qt6-tools-dev-tools libqt6core5compat6-dev libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext ninja-build
+sudo apt install g++ cmake extra-cmake-modules qt6-base-dev qt6-tools-dev-tools libqt6core5compat6-dev qt6-tools-dev libsdl2-dev libxi-dev libxtst-dev libx11-dev itstool gettext ninja-build
 ```
 
 QT5 Variant:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -822,7 +822,12 @@ endif()
 
 # Building .deb package
 if(CPACK_GENERATOR STREQUAL "DEB")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "qtbase5-dev (>= ${QT_REQUIRED_VERSION}), libsdl2-2.0-0 (>= ${SDL_REQUIRED_VERSION}), libc6")
+    if(QT_VERSION_MAJOR EQUAL 5)
+        # TODO use regular, not dev packages
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5widgets5 (>= ${QT_REQUIRED_VERSION}), libsdl2-2.0-0 (>= ${SDL_REQUIRED_VERSION}), libc6")
+    else()
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt6widgets6t64 (>= ${QT_REQUIRED_VERSION}), libsdl2-2.0-0 (>= ${SDL_REQUIRED_VERSION}), libc6")
+    endif(QT_VERSION_MAJOR EQUAL 5)
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "pktiuk <kotiuk@zohomail.eu>")
     set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "AntiMicroX is a graphical program used to map gamepad buttons to keyboard, mouse, scripts and macros.
 


### PR DESCRIPTION
Closes: https://github.com/AntiMicroX/antimicrox/issues/1031