### PR TITLE
wayland: Fix appId

### DIFF
--- a/other/io.github.antimicrox.antimicrox.desktop
+++ b/other/io.github.antimicrox.antimicrox.desktop
@@ -17,7 +17,6 @@ Categories=Game;Qt;Utility;
 MimeType=application/x-amgp;
 Keywords=game;controller;keyboard;joystick;mouse;
 Actions=run-in-tray;
-StartupWMClass=antimicrox
 
 [Desktop Action run-in-tray]
 Name=Open in system tray only

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -419,6 +419,9 @@ int main(int argc, char *argv[])
     QTranslator qtTranslator;
 
 #if defined(Q_OS_UNIX)
+    // Ensure that the Wayland appId matches the .desktop file name
+    QGuiApplication::setDesktopFileName("io.github.antimicrox.antimicrox");
+
     installSignalHandlers();
 
     QString transPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);


### PR DESCRIPTION
## Proposed changes 
In a Wayland session the window appId defaults to the name of the binary (`antimicrox`). This does not match the name of the .desktop launcher, so freedesktop-compliant compositors don't correctly associate the windows with the launcher. This corrects that behavior.