### PR TITLE
Update Linux appstream metadata

### DIFF
--- a/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in
+++ b/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in
@@ -12,7 +12,7 @@
   <description>
     <p>AntiMicroX is a graphical program used to map gamepad buttons/joysticks
      to keyboard, mouse, scripts and macros.
-     It can be also used for generating SLD2 configuration (useful for mapping 
+     It can be also used for generating SDL2 configuration (useful for mapping 
      atypical gamepads to generic ones like xbox360).</p>
     <p>Features:</p>
     <ul>

--- a/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in
+++ b/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in
@@ -10,15 +10,10 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <description>
-    <p>AntiMicroX is a graphical program used to map gamepad buttons/joysticks
-     to keyboard, mouse, scripts and macros.
-     It can be also used for generating SDL2 configuration (useful for mapping 
-     atypical gamepads to generic ones like xbox360).</p>
+    <p>AntiMicroX is a graphical program used to map gamepad buttons/joysticks to keyboard, mouse, scripts and macros. It can be also used for generating SDL2 configuration (useful for mapping atypical gamepads to generic ones like xbox360).</p>
     <p>Features:</p>
     <ul>
-      <li>
-        Mapping of gamepads/joystick buttons to: ⌨️keyboard buttons, 🖱️mouse buttons and moves, scripts, executables and macros consisting of elements mentioned here
-      </li>
+      <li>Mapping of gamepads/joystick buttons to: ⌨️keyboard buttons, 🖱️mouse buttons and moves, scripts, executables and macros consisting of elements mentioned here.</li>
       <li>Assigning multiple switchable sets of mappings to gamepad.</li>
       <li>Auto profiles - assign profile to active application window.</li>
     </ul>

--- a/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in
+++ b/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in
@@ -83,6 +83,10 @@
     <category>Utility</category>
     <category>Qt</category>
   </categories>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
   <recommends>
     <control>gamepad</control>
   </recommends>


### PR DESCRIPTION
## Proposed changes 

These changes fix displaying AntiMicroX from Flathub in GNOME Software on Debian 12.

- Fix spelling of SDL2
- Fix description formatting (paragraph split on multiple lines, line breaks in features list)
- List mouse/keyboard as supported ([see spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-control)).

The AntiMicroX Flatpak builds and installs with these changes. Though it doesn't override the description in GNOME Software so it's not possible to fully confirm the result.

----

Screenshots of the current behavior:

![Screenshot from 2025-01-23 06-31-29](https://github.com/user-attachments/assets/8f54926c-aa84-487f-b2cb-883326d1c5c8)

![Screenshot from 2025-01-23 06-31-36](https://github.com/user-attachments/assets/e7c810f2-c893-4aa9-84cc-052e21578e5d)
