### PR TITLE
fix: Use warning log level by default as stated in manual.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationVersion(PadderCommon::programVersion);
 
     QTextStream outstream(stdout);
-    Logger *appLogger = Logger::createInstance(&outstream, Logger::LogLevel::LOG_DEBUG);
+    Logger *appLogger = Logger::createInstance(&outstream, Logger::LogLevel::LOG_WARNING);
 
     qRegisterMetaType<JoyButtonSlot *>();
     qRegisterMetaType<SetJoystick *>();


### PR DESCRIPTION
Closes: https://github.com/AntiMicroX/antimicrox/issues/1158