### PR TITLE
Update io.github.antimicrox.antimicrox.desktop with StartupWMClass=antimicrox

### DIFF
--- a/other/io.github.antimicrox.antimicrox.desktop
+++ b/other/io.github.antimicrox.antimicrox.desktop
@@ -17,6 +17,7 @@ Categories=Game;Qt;Utility;
 MimeType=application/x-amgp;
 Keywords=game;controller;keyboard;joystick;mouse;
 Actions=run-in-tray;
+StartupWMClass=antimicrox
 
 [Desktop Action run-in-tray]
 Name=Open in system tray only


### PR DESCRIPTION

hello! 🙂
Gnome dash shows generic icon if desktop file doesn't have StartupWMClass=antimicrox
so if you can merge this its cool 👍