### PR TITLE
fix: flatpak: request wayland socket

### DIFF
--- a/other/io.github.antimicrox.antimicrox.yml
+++ b/other/io.github.antimicrox.antimicrox.yml
@@ -2,13 +2,14 @@
 
 app-id: io.github.antimicrox.antimicrox
 runtime: org.kde.Platform
-runtime-version: '5.11'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: antimicrox
 finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   # Gamepads
   - --device=all
 


### PR DESCRIPTION
Without x11 support, and no wayland socket permission, the startup segfaults.

```
#0  0x0000ffff83280610 in __pthread_kill_implementation () from /usr/lib/aarch64-linux-gnu/libc.so.6
#1  0x0000ffff832397ec in raise () from /usr/lib/aarch64-linux-gnu/libc.so.6
#2  0x0000ffff832248bc in abort () from /usr/lib/aarch64-linux-gnu/libc.so.6
#3  0x0000ffff837d6abc in QMessageLogger::fatal(char const*, ...) const () from /usr/lib/aarch64-linux-gnu/libQt5Core.so.5
#4  0x0000ffff83e3683c in QGuiApplicationPrivate::createPlatformIntegration() () from /usr/lib/aarch64-linux-gnu/libQt5Gui.so.5
#5  0x0000ffff83e36c28 in QGuiApplicationPrivate::createEventDispatcher() () from /usr/lib/aarch64-linux-gnu/libQt5Gui.so.5
#6  0x0000ffff83a050e8 in QCoreApplicationPrivate::init() () from /usr/lib/aarch64-linux-gnu/libQt5Core.so.5
#7  0x0000ffff83e39e80 in QGuiApplicationPrivate::init() () from /usr/lib/aarch64-linux-gnu/libQt5Gui.so.5
#8  0x0000ffff848e0218 in QApplicationPrivate::init() () from /usr/lib/aarch64-linux-gnu/libQt5Widgets.so.5
#9  0x0000aaaae671f604 in main (argc=<optimized out>, argv=<optimized out>) at /run/build/antimicrox/src/main.cpp:232
```
Closes #1190

## Proposed changes 

- 
- 
- 

----


<!-- 
    Please, go through these steps before you submit a PR.

    Make sure that your PR is not a duplicate.

    If not, then make sure that:

    - You have done your changes in a separate branch.

    - You have a descriptive, semantic commit messages with a short title (first line). E.g. `fix(calibration): fix calibration dialog buttons`

    - Provide a description of your changes, with screenshots if possible

    - Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
    
    - When merging, don't forget to squash commits! -->

