### PR TITLE
ci: chore: Drop usage of Ubuntu 20.04 Runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
                       build-type: Debug
                       experimental: true
                       qt-packages: "qttools5-dev qttools5-dev-tools"
-                    - name: Ubuntu 20-04 GCC  (for AppImage comp)
-                      image: ubuntu-20.04
+                    - name: Ubuntu 22-04 GCC  (for AppImage comp)
+                      image: ubuntu-22.04
                       cc: gcc
                       cxx: g++
                       build-type: Debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
                 image: ubuntu-24.04
               - name: Ubuntu 22-04
                 image: ubuntu-22.04
-              - name: Ubuntu 20-04
-                image: ubuntu-20.04
         name: Build deb package ${{ matrix.name }}
         runs-on: ${{ matrix.image }}
 
@@ -55,7 +53,7 @@ jobs:
     build-appimage:
         # Version of ubuntu building this appimage, it shouldn't be the latest verion of ubuntu to avoid breaking compatibility with older systems
         name: Build AppImage package
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
 
         steps:
 


### PR DESCRIPTION
Ubuntu 20 is not supported anymore, it is also not available as GitHub Runner