### PR TITLE
joystickstatuswindow: don't update accel/gyro if closed

### DIFF
--- a/src/gui/joystickstatuswindow.cpp
+++ b/src/gui/joystickstatuswindow.cpp
@@ -302,6 +302,8 @@ JoystickStatusWindow::JoystickStatusWindow(InputDevice *joystick, QWidget *paren
     connect(this, &JoystickStatusWindow::finished, this, &JoystickStatusWindow::restoreButtonStates);
 }
 
+void JoystickStatusWindow::reject() { this->deleteLater(); }
+
 JoystickStatusWindow::~JoystickStatusWindow() { delete ui; }
 
 void JoystickStatusWindow::restoreButtonStates(int code)

--- a/src/gui/joystickstatuswindow.h
+++ b/src/gui/joystickstatuswindow.h
@@ -44,6 +44,7 @@ class JoystickStatusWindow : public QDialog
     InputDevice *getJoystick() const;
 
   private:
+    void reject();
     Ui::JoystickStatusWindow *ui;
 
     InputDevice *joystick;


### PR DESCRIPTION
Avoid updating the accelerometer or gyroscope values if the window is closed. This prevents a segfault when the window is closed for controllers with accelerometers and gyroscopes, such as DualSense controllers.