### PR TITLE
fix: Always require X11 socket in Flatpak manifest

### DIFF
--- a/other/io.github.antimicrox.antimicrox.yml
+++ b/other/io.github.antimicrox.antimicrox.yml
@@ -10,7 +10,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # X11 + XShm access
   - --share=ipc
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=wayland
   # Gamepads
   - --device=all


### PR DESCRIPTION
See: https://github.com/AntiMicroX/antimicrox/issues/1131#issuecomment-3686904700

AntiMicroX crashes without access to the X11 socket, even under Wayland, so it needs socket=x11 rather than socket=fallback-x11.  This way, it always gets access to the X11 socket.

Edit: Maybe this doesn't specifically fix the issue reported in #1131, because they weren't using Flatpak.  I found #1201 reported for Flatpak though, that's the one for this issue.

Fixes #1201