### PR TITLE
refactor: initialize AntKeyMapper members only when they are needed

### DIFF
--- a/src/antkeymapper.cpp
+++ b/src/antkeymapper.cpp
@@ -52,7 +52,7 @@ AntKeyMapper::AntKeyMapper(QString handler, QObject *parent)
     #ifdef WITH_XTEST
     if (handler == "xtest")
     {
-        internalMapper = &x11Mapper;
+        internalMapper = new QtX11KeyMapper(this);
         nativeKeyMapper = nullptr;
     }
     #endif
@@ -60,9 +60,9 @@ AntKeyMapper::AntKeyMapper(QString handler, QObject *parent)
     #ifdef WITH_UINPUT
     if (handler == "uinput")
     {
-        internalMapper = &uinputMapper;
+        internalMapper = new QtUInputKeyMapper(this);
         #ifdef WITH_XTEST
-        nativeKeyMapper = &x11Mapper;
+        nativeKeyMapper = new QtX11KeyMapper(this);
         #else
         nativeKeyMapper = nullptr;
         #endif
@@ -71,7 +71,7 @@ AntKeyMapper::AntKeyMapper(QString handler, QObject *parent)
 #elif defined Q_OS_WIN
     BACKEND_ELSE_IF(handler == "sendinput")
     {
-        internalMapper = &winMapper;
+        internalMapper = new QtWinKeyMapper(this);
         nativeKeyMapper = 0;
     }
 #endif

--- a/src/antkeymapper.h
+++ b/src/antkeymapper.h
@@ -56,18 +56,6 @@ class AntKeyMapper : public QObject
 
     QtKeyMapperBase *internalMapper;
     QtKeyMapperBase *nativeKeyMapper;
-
-#ifdef Q_OS_WIN
-    QtWinKeyMapper winMapper;
-#else
-    #if defined(WITH_XTEST)
-    QtX11KeyMapper x11Mapper;
-    #endif
-
-    #if defined(WITH_UINPUT)
-    QtUInputKeyMapper uinputMapper;
-    #endif
-#endif
 };
 
 #endif // ANTKEYMAPPER_H


### PR DESCRIPTION
Linked with https://github.com/AntiMicroX/antimicrox/issues/1201 and https://github.com/AntiMicroX/antimicrox/pull/1257 (does not tackle the root cause)