### PR TITLE
Add Event Handler checks for no X11 scenarios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ if(UNIX)
         message("Cannot use XTest without X11. Disabling XTest support.")
     endif(WITH_XTEST AND NOT WITH_X11)
 
+    if(NOT WITH_X11 AND NOT WITH_UINPUT)
+        message(FATAL_ERROR "No system is defined for simulating events. At least one of WITH_X11 or WITH_UINPUT must be enabled.")
+    endif(NOT WITH_X11 AND NOT WITH_UINPUT)
+
     if(WITH_XTEST)
         message("XTest support allowed for simulating events.")
     endif(WITH_XTEST)

--- a/src/eventhandlerfactory.cpp
+++ b/src/eventhandlerfactory.cpp
@@ -21,6 +21,7 @@
 
 #include "eventhandlers/baseeventhandler.h"
 
+#include <QApplication>
 #include <QDebug>
 #include <QHash>
 
@@ -45,27 +46,38 @@ EventHandlerFactory *EventHandlerFactory::instance = nullptr;
 
 EventHandlerFactory::EventHandlerFactory(QString handler, QObject *parent)
     : QObject(parent)
+    , eventHandler(nullptr)
 {
+    VERBOSE() << "EventHandlerFactory: requested handler=" << handler;
+
 #ifdef WITH_UINPUT
-
     if (handler == "uinput")
+    {
+        VERBOSE() << "EventHandlerFactory: initializing uinput handler.";
         eventHandler = new UInputEventHandler(this);
-
+    }
 #endif
 
 #ifdef WITH_XTEST
-
     if (handler == "xtest")
+    {
+        VERBOSE() << "EventHandlerFactory: initializing xtest handler.";
         eventHandler = new XTestEventHandler(this);
-
+    }
 #endif
 
 #if defined(Q_OS_WIN)
     if (handler == "sendinput")
     {
+        VERBOSE() << "EventHandlerFactory: initializing sendinput handler.";
         eventHandler = new WinSendInputEventHandler(this);
     }
 #endif
+
+    if (eventHandler == nullptr)
+    {
+        WARN() << "EventHandlerFactory: no event handler created for handler identifier" << handler;
+    }
 }
 
 EventHandlerFactory *EventHandlerFactory::getInstance(QString handler)
@@ -92,12 +104,20 @@ void EventHandlerFactory::deleteInstance()
     }
 }
 
-BaseEventHandler *EventHandlerFactory::handler() { return eventHandler; }
+BaseEventHandler *EventHandlerFactory::handler()
+{
+    if (instance == nullptr)
+    {
+        ERROR() << "EventHandlerFactory: No instance exists when handler() was called.Closing application.";
+        qApp->quit();
+    }
+    return eventHandler;
+}
 
 QString EventHandlerFactory::fallBackIdentifier()
 {
 #if defined(Q_OS_UNIX)
-    static QString temp = "xtest";
+    static QString temp = QString();
     static bool identifier_obtained = false;
     if (identifier_obtained)
         return temp;
@@ -105,11 +125,13 @@ QString EventHandlerFactory::fallBackIdentifier()
 
     bool compiled_with_x11 = false;
     bool compiled_with_uinput = false;
-    #if defined(WITH_XTEST)
-    compiled_with_x11 = true;
-    #endif
     #if defined(WITH_UINPUT)
     compiled_with_uinput = true;
+    temp = "uinput";
+    #endif
+    #if defined(WITH_XTEST)
+    compiled_with_x11 = true;
+    temp = "xtest";
     #endif
 
     if (detected_xdg_session == "wayland")


### PR DESCRIPTION
Fixes issue: https://github.com/AntiMicroX/antimicrox/issues/1308

I see app failed when it tried to get identifier (in X11 environment without X11 flag enabled)

```
#0  0x00005956bb29190e in main (argc=<optimized out>, argv=<optimized out>)
    at /run/build/antimicrox/src/main.cpp:489
489             eventGeneratorIdentifier = factory->handler()->getIdentifier();
```

I guess that this was caused by invalid identifier validation


```cpp
EventHandlerFactory::EventHandlerFactory(QString handler, QObject *parent) //HANDLER value == xtest
    : QObject(parent)
{
#ifdef WITH_UINPUT -THIS BLOCK ENABLED

    if (handler == "uinput")
        eventHandler = new UInputEventHandler(this);

#endif

#ifdef WITH_XTEST  --THIS BLOCK DISABLED

    if (handler == "xtest")
        eventHandler = new XTestEventHandler(this);

#endif
}
```


