### PR TITLE
feat: scale trigger mouse speed modifiers by analog travel (refs #1192)

### DIFF
--- a/src/gamecontroller/gamecontrollertriggerbutton.cpp
+++ b/src/gamecontroller/gamecontrollertriggerbutton.cpp
@@ -34,3 +34,8 @@ GameControllerTriggerButton::GameControllerTriggerButton(JoyAxis *axis, int inde
 }
 
 QString GameControllerTriggerButton::getXmlName() { return GlobalVariables::GameControllerTriggerButton::xmlName; }
+
+double GameControllerTriggerButton::getMouseSpeedModifier(JoyButtonSlot *slot)
+{
+    return calculateMouseSpeedModifier(slot->getSlotCode(), getMouseDistanceFromDeadZone());
+}

--- a/src/gamecontroller/gamecontrollertriggerbutton.h
+++ b/src/gamecontroller/gamecontrollertriggerbutton.h
@@ -21,6 +21,8 @@
 
 #include "joybuttontypes/joyaxisbutton.h"
 
+#include <QtGlobal>
+
 class QXmlStreamReader;
 class SetJoystick;
 class JoyAxis;
@@ -34,6 +36,16 @@ class GameControllerTriggerButton : public JoyAxisButton
                                          QObject *parent = nullptr);
 
     virtual QString getXmlName();
+    static double calculateMouseSpeedModifier(int slotCode, double distance)
+    {
+        double targetModifier = slotCode * 0.01;
+        double boundedDistance = qBound(0.0, distance, 1.0);
+
+        return 1.0 + ((targetModifier - 1.0) * boundedDistance);
+    }
+
+  protected:
+    virtual double getMouseSpeedModifier(JoyButtonSlot *slot) override;
 };
 
 #endif // GAMECONTROLLERBUTTON_H

--- a/src/joybuttontypes/joybutton.cpp
+++ b/src/joybuttontypes/joybutton.cpp
@@ -46,6 +46,7 @@ JoyButtonSlot *JoyButton::lastActiveKey = nullptr;
 
 // Keep track of active Mouse Speed Mod slots.
 QList<JoyButtonSlot *> JoyButton::mouseSpeedModList;
+QHash<JoyButtonSlot *, JoyButton *> JoyButton::mouseSpeedModButtons;
 
 // Lists used for cursor mode calculations.
 QList<JoyButton::mouseCursorInfo> JoyButton::cursorXSpeeds;
@@ -893,8 +894,9 @@ void JoyButton::addEachSlotToActives(JoyButtonSlot *slot, int &i, bool &delaySeq
 
         qDebug() << i << ": It's a JoyMouseSpeedMod with code: " << tempcode << " and name: " << slot->getSlotString();
 
-        GlobalVariables::JoyButton::mouseSpeedModifier = tempcode * 0.01;
         mouseSpeedModList.append(slot);
+        mouseSpeedModButtons.insert(slot, this);
+        updateMouseSpeedModifier();
         getActiveSlotsLocal().append(slot);
 
         break;
@@ -1003,6 +1005,7 @@ void JoyButton::mouseEvent()
 
     if ((buttonslot != nullptr) || !mouseEventQueue.isEmpty())
     {
+        updateMouseSpeedModifier();
         updateMouseParams(true, true, 0.0);
 
         QQueue<JoyButtonSlot *> tempQueue;
@@ -2947,6 +2950,23 @@ double JoyButton::getAccelerationDistance() { return this->getDistanceFromDeadZo
  */
 double JoyButton::getMouseDistanceFromDeadZone() { return this->getDistanceFromDeadZone(); }
 
+double JoyButton::getMouseSpeedModifier(JoyButtonSlot *slot) { return slot->getSlotCode() * 0.01; }
+
+void JoyButton::updateMouseSpeedModifier()
+{
+    double modifier = GlobalVariables::JoyButton::DEFAULTMOUSESPEEDMOD;
+
+    for (JoyButtonSlot *slot : qAsConst(mouseSpeedModList))
+    {
+        JoyButton *button = mouseSpeedModButtons.value(slot, nullptr);
+
+        if (button != nullptr)
+            modifier *= button->getMouseSpeedModifier(slot);
+    }
+
+    GlobalVariables::JoyButton::mouseSpeedModifier = modifier;
+}
+
 double JoyButton::getTotalSlotDistance(JoyButtonSlot *slot)
 {
     double tempDistance = 0.0;
@@ -3245,16 +3265,14 @@ void JoyButton::releaseEachSlot(bool &changeRepeatState, int &references, int te
         slot->getMouseInterval()->restart();
     } else if (mode == JoyButtonSlot::JoyMouseSpeedMod)
     {
-        int queueLength = mouseSpeedModList.length();
+        mouseSpeedModButtons.remove(slot);
 
         if (!mouseSpeedModList.isEmpty())
         {
             mouseSpeedModList.removeAll(slot);
-            queueLength -= 1;
         }
 
-        if (queueLength <= 0)
-            GlobalVariables::JoyButton::mouseSpeedModifier = GlobalVariables::JoyButton::DEFAULTMOUSESPEEDMOD;
+        updateMouseSpeedModifier();
     } else if (mode == JoyButtonSlot::JoySetChange)
     {
         currentSetChangeSlot = slot;

--- a/src/joybuttontypes/joybutton.h
+++ b/src/joybuttontypes/joybutton.h
@@ -25,6 +25,7 @@
 #include "springmousemoveinfo.h"
 
 #include <QDeadlineTimer>
+#include <QHash>
 #include <QQueue>
 #include <QReadWriteLock>
 #include <QRunnable>
@@ -281,16 +282,19 @@ class JoyButton : public QObject
     void localBuildActiveZoneSummaryString();
 
     static bool hasFutureSpringEvents(QList<JoyButton *> *pendingMouseButtons);
+    static void updateMouseSpeedModifier();
     static int timeBetweenMiniSlots;
     static int allSlotTimeBetweenSlots;
 
     virtual double getCurrentSpringDeadCircle();
+    virtual double getMouseSpeedModifier(JoyButtonSlot *slot);
 
     TurboMode currentTurboMode;
 
     QString buildActiveZoneSummary(QList<JoyButtonSlot *> &tempList);
 
     static QList<JoyButtonSlot *> mouseSpeedModList; // JoyButtonSlots class
+    static QHash<JoyButtonSlot *, JoyButton *> mouseSpeedModButtons;
     static QList<mouseCursorInfo> cursorXSpeeds;
     static QList<mouseCursorInfo> cursorYSpeeds;
     static QList<PadderCommon::springModeInfo> springXSpeeds;


### PR DESCRIPTION
## Summary
- track the owning button for active Mouse Speed Mod slots and recompute the combined modifier before mouse movement is processed
- make trigger-owned Mouse Speed Mod slots interpolate from 100% at rest to the configured percentage at full trigger travel
- preserve fixed Mouse Speed Mod behavior for normal buttons while combining simultaneous active modifiers multiplicatively

## Testing
- `git diff --check`
- focused compile checks for the modified mouse speed and trigger button translation units
- trigger modifier smoke covering 50% and 200% Mouse Speed Mod values across partial and full trigger travel