### PR TITLE
fix: Correct grammar mistake in message

### DIFF
--- a/share/antimicrox/translations/antimicrox.ts
+++ b/share/antimicrox/translations/antimicrox.ts
@@ -1538,8 +1538,8 @@ this button is being used.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
-        <translation>Before you open window with advanced settings, you have to choice a key</translation>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
+        <translation>Before you open window with advanced settings, you have to choose a key</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="398"/>

--- a/share/antimicrox/translations/antimicrox_br.ts
+++ b/share/antimicrox/translations/antimicrox_br.ts
@@ -1526,7 +1526,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_ca.ts
+++ b/share/antimicrox/translations/antimicrox_ca.ts
@@ -1858,7 +1858,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_cs.ts
+++ b/share/antimicrox/translations/antimicrox_cs.ts
@@ -1541,7 +1541,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_da.ts
+++ b/share/antimicrox/translations/antimicrox_da.ts
@@ -1530,7 +1530,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_de.ts
+++ b/share/antimicrox/translations/antimicrox_de.ts
@@ -1575,7 +1575,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Bevor du ein Fenster mit den erweiterten Einstellungen öffnest, musst du einen Schlüssel wählen</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_en.ts
+++ b/share/antimicrox/translations/antimicrox_en.ts
@@ -1538,8 +1538,8 @@ this button is being used.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
-        <translation>Before you open window with advanced settings, you have to choice a key</translation>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
+        <translation>Before you open window with advanced settings, you have to choose a key</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="398"/>

--- a/share/antimicrox/translations/antimicrox_es.ts
+++ b/share/antimicrox/translations/antimicrox_es.ts
@@ -1775,7 +1775,7 @@ se utiliza este botón.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Antes de abrir la ventana con la configuración avanzada, debe elegir una tecla</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_fa.ts
+++ b/share/antimicrox/translations/antimicrox_fa.ts
@@ -1531,7 +1531,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_fi.ts
+++ b/share/antimicrox/translations/antimicrox_fi.ts
@@ -1864,7 +1864,7 @@ kun tätä painiketta käytetään.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Ennen kuin avaat ikkunan edistyneempien asetusten suhteen, tulee sinun valita painike</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_fr.ts
+++ b/share/antimicrox/translations/antimicrox_fr.ts
@@ -1609,7 +1609,7 @@ lorsque que ce bouton est utilisé.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Avant d&apos;ouvrir la fenêtre des options avancées, vous devez d&apos;abord choisir une touche</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_hr.ts
+++ b/share/antimicrox/translations/antimicrox_hr.ts
@@ -1526,7 +1526,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_id.ts
+++ b/share/antimicrox/translations/antimicrox_id.ts
@@ -1601,7 +1601,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_it.ts
+++ b/share/antimicrox/translations/antimicrox_it.ts
@@ -1678,7 +1678,7 @@ mentre questo tasto viene usato.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Prima di aprire la finestra delle impostazioni avanzate, devi scegliere un tasto</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_ja.ts
+++ b/share/antimicrox/translations/antimicrox_ja.ts
@@ -1530,7 +1530,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_ko.ts
+++ b/share/antimicrox/translations/antimicrox_ko.ts
@@ -1865,7 +1865,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>고급 설정으로 창을 열기 전에 키 선택</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_nb_NO.ts
+++ b/share/antimicrox/translations/antimicrox_nb_NO.ts
@@ -1714,7 +1714,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_nl.ts
+++ b/share/antimicrox/translations/antimicrox_nl.ts
@@ -1526,7 +1526,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_pl.ts
+++ b/share/antimicrox/translations/antimicrox_pl.ts
@@ -1538,7 +1538,7 @@ gdy przycisk jest wciśnięty.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Zanim otworzysz okno z zaawansowanymi ustawieniami, musisz wybrać klawisz</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_pt.ts
+++ b/share/antimicrox/translations/antimicrox_pt.ts
@@ -1598,7 +1598,7 @@ este botão for pressionado.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Antes de abrir a janela de configurações avançadas, você precisa escolher uma tecla</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_pt_BR.ts
+++ b/share/antimicrox/translations/antimicrox_pt_BR.ts
@@ -1837,7 +1837,7 @@ este botão estiver sendo usado.</translation>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>Antes de abrir a janela com as configurações avançadas, você precisa escolher uma tecla</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_ru.ts
+++ b/share/antimicrox/translations/antimicrox_ru.ts
@@ -1989,7 +1989,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished">Прежде чем открыть окно с расширенными настройками, необходимо выбрать клавишу</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_rue.ts
+++ b/share/antimicrox/translations/antimicrox_rue.ts
@@ -1526,7 +1526,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_sk.ts
+++ b/share/antimicrox/translations/antimicrox_sk.ts
@@ -1530,7 +1530,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_sr.ts
+++ b/share/antimicrox/translations/antimicrox_sr.ts
@@ -1542,7 +1542,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_sv.ts
+++ b/share/antimicrox/translations/antimicrox_sv.ts
@@ -1588,7 +1588,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_ta.ts
+++ b/share/antimicrox/translations/antimicrox_ta.ts
@@ -1679,7 +1679,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>மேம்பட்ட அமைப்புகளுடன் சாளரத்தைத் திறப்பதற்கு முன், நீங்கள் ஒரு விசையை தேர்வு செய்ய வேண்டும்</translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_tr.ts
+++ b/share/antimicrox/translations/antimicrox_tr.ts
@@ -1535,7 +1535,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_uk.ts
+++ b/share/antimicrox/translations/antimicrox_uk.ts
@@ -1549,7 +1549,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_vi.ts
+++ b/share/antimicrox/translations/antimicrox_vi.ts
@@ -1526,7 +1526,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/antimicrox/translations/antimicrox_zh_CN.ts
+++ b/share/antimicrox/translations/antimicrox_zh_CN.ts
@@ -1659,7 +1659,7 @@ this button is being used.</source>
     </message>
     <message>
         <location filename="../../../src/gui/buttoneditdialog.cpp" line="391"/>
-        <source>Before you open window with advanced settings, you have to choice a key</source>
+        <source>Before you open window with advanced settings, you have to choose a key</source>
         <translation>请先绑定一个按键再进入高级选项</translation>
     </message>
     <message>

--- a/src/gui/buttoneditdialog.cpp
+++ b/src/gui/buttoneditdialog.cpp
@@ -388,7 +388,7 @@ void ButtonEditDialog::openAdvancedDialog()
         } else
         {
             QMessageBox::information(this, tr("No choice"),
-                                     tr("Before you open window with advanced settings, you have to choice a key"));
+                                     tr("Before you open window with advanced settings, you have to choose a key"));
         }
 
     } else


### PR DESCRIPTION
This commit changes a word in the GUI that was in the incorrect form. I have also corrected it wherever it appears untranslated in the translations/ directory.
