### PR TITLE
Fix changelog external links

### DIFF
--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -104,6 +104,7 @@ void AboutDialog::fillInfoTextBrowser()
 #else
     ui->changelogText->setPlainText(changelogText);
 #endif
+    ui->changelogText->setOpenExternalLinks(true);
 }
 
 void AboutDialog::changeEvent(QEvent *event)

--- a/tests/testaboutdialog.cpp
+++ b/tests/testaboutdialog.cpp
@@ -35,6 +35,7 @@ private slots:
     void testVersion();
     void infoTextBrowserEmpty();
     void changelogPlainEmpty();
+    void changelogOpensExternalLinks();
     void textBrowserDevsEmpty();
     void licenseInfoEmpty();
     void creditsInfoEmpty();
@@ -58,8 +59,16 @@ void TestAboutDialog::infoTextBrowserEmpty()
 
 void TestAboutDialog::changelogPlainEmpty()
 {
-    QPlainTextEdit* changelogText = aboutDialog.findChild<QPlainTextEdit*>("changelogText");
+    QTextBrowser* changelogText = aboutDialog.findChild<QTextBrowser*>("changelogText");
+    QVERIFY2(changelogText != nullptr, "changelogText is missing");
     QVERIFY2(!changelogText->toPlainText().isEmpty(), "changelogText is empty");
+}
+
+void TestAboutDialog::changelogOpensExternalLinks()
+{
+    QTextBrowser* changelogText = aboutDialog.findChild<QTextBrowser*>("changelogText");
+    QVERIFY2(changelogText != nullptr, "changelogText is missing");
+    QVERIFY2(changelogText->openExternalLinks(), "changelogText should open external links outside the text browser");
 }
 
 void TestAboutDialog::textBrowserDevsEmpty()


### PR DESCRIPTION
## Summary
- Enable external link handling for the About dialog changelog text browser.
- Update the About dialog test to look up `changelogText` as a `QTextBrowser` and assert external links are enabled.

Fixes #571.

## Validation
- `git diff --check`

I could not run the Qt/CMake test suite locally because this Windows environment does not have `cmake`, `ninja`, or `qmake` available in PATH.