### PR TITLE
feat(auto profiles): release controller capture for matched applications

### DIFF
--- a/src/autoprofileinfo.cpp
+++ b/src/autoprofileinfo.cpp
@@ -31,6 +31,7 @@ AutoProfileInfo::AutoProfileInfo(QString uniqueID, QString profileLocation, QStr
     setActive(active);
     setDefaultState(false);
     setPartialState(partialTitle);
+    setReleaseController(false);
 }
 
 AutoProfileInfo::AutoProfileInfo(QString uniqueID, QString profileLocation, bool active, bool partialTitle, QObject *parent)
@@ -41,6 +42,7 @@ AutoProfileInfo::AutoProfileInfo(QString uniqueID, QString profileLocation, bool
     setActive(active);
     setDefaultState(false);
     setPartialState(partialTitle);
+    setReleaseController(false);
 }
 
 AutoProfileInfo::AutoProfileInfo(QObject *parent)
@@ -49,6 +51,7 @@ AutoProfileInfo::AutoProfileInfo(QObject *parent)
     setActive(true);
     setDefaultState(false);
     setPartialState(false);
+    setReleaseController(false);
 }
 
 AutoProfileInfo::~AutoProfileInfo() {}
@@ -130,9 +133,14 @@ void AutoProfileInfo::setPartialState(bool value) { this->partialState = value; 
 
 bool AutoProfileInfo::isPartialState() { return partialState; }
 
+void AutoProfileInfo::setReleaseController(bool value) { this->releaseController = value; }
+
+bool AutoProfileInfo::shouldReleaseController() const { return releaseController; }
+
 QString AutoProfileInfo::toString() const
 {
     return QString("ID of assigned controller:%1, Profile Location:%2, Exe:%3,WindowClass:%4, WindowName:%5, isActive:%6, "
-                   "DeviceName:%7")
-        .arg(uniqueID, profileLocation, exe, windowClass, windowName, active ? "true" : "false", deviceName);
+                   "DeviceName:%7, ReleaseController:%8")
+        .arg(uniqueID, profileLocation, exe, windowClass, windowName, active ? "true" : "false", deviceName,
+             releaseController ? "true" : "false");
 }

--- a/src/autoprofileinfo.h
+++ b/src/autoprofileinfo.h
@@ -64,6 +64,9 @@ class AutoProfileInfo : public QObject
     void setPartialState(bool value);
     bool isPartialState();
 
+    void setReleaseController(bool value);
+    bool shouldReleaseController() const;
+
     QString toString() const;
 
   private:
@@ -76,6 +79,7 @@ class AutoProfileInfo : public QObject
     bool active;
     bool defaultState;
     bool partialState;
+    bool releaseController;
 };
 
 Q_DECLARE_METATYPE(AutoProfileInfo *)

--- a/src/autoprofilewatcher.cpp
+++ b/src/autoprofilewatcher.cpp
@@ -309,26 +309,73 @@ void AutoProfileWatcher::runAppCheck()
             }
         }
 
+        QList<AutoProfileInfo *> applicableProfiles;
+
         for (auto &&info : highestMatches)
         {
             getUniqeIDSetLocal().insert(info->getUniqueID());
-            emit foundApplicableProfile(info);
+            applicableProfiles.append(info);
         }
 
         if ((!getDefaultProfileAssignments().isEmpty() || allDefaultInfo) && !focusedWidget)
         {
             if (allDefaultInfo != nullptr && allDefaultInfo->isActive() && !getUniqeIDSetLocal().contains("all"))
             {
-                emit foundApplicableProfile(allDefaultInfo);
+                applicableProfiles.append(allDefaultInfo);
             }
 
             for (auto &&info : getDefaultProfileAssignments())
             {
                 if (info->isActive() && !getUniqeIDSetLocal().contains(info->getUniqueID()))
                 {
-                    emit foundApplicableProfile(info);
+                    applicableProfiles.append(info);
                 }
             }
+        }
+
+        AutoProfileInfo *releaseAllAutoProfile = nullptr;
+        QList<AutoProfileInfo *> releaseControllerProfiles;
+        QSet<QString> releaseControllerUniqueIDs;
+        for (AutoProfileInfo *info : applicableProfiles)
+        {
+            if (info->shouldReleaseController())
+            {
+                if (info->getUniqueID() == "all")
+                {
+                    releaseAllAutoProfile = info;
+                    break;
+                }
+
+                releaseControllerProfiles.append(info);
+                releaseControllerUniqueIDs.insert(info->getUniqueID());
+            }
+        }
+
+        if (releaseAllAutoProfile != nullptr)
+        {
+            emit foundApplicableProfile(releaseAllAutoProfile);
+            return;
+        }
+
+        if (!releaseControllerUniqueIDs.isEmpty())
+        {
+            for (AutoProfileInfo *info : applicableProfiles)
+            {
+                if (!info->shouldReleaseController() && !releaseControllerUniqueIDs.contains(info->getUniqueID()))
+                    emit foundApplicableProfile(info);
+            }
+
+            for (AutoProfileInfo *info : releaseControllerProfiles)
+            {
+                emit foundApplicableProfile(info);
+            }
+
+            return;
+        }
+
+        for (AutoProfileInfo *info : applicableProfiles)
+        {
+            emit foundApplicableProfile(info);
         }
     }
 }
@@ -354,6 +401,7 @@ void AutoProfileWatcher::syncProfileAssignment()
 
     QString allProfile = settings->value(QString("DefaultAutoProfileAll/Profile"), "all").toString();
     QString allActive = settings->value(QString("DefaultAutoProfileAll/Active"), "0").toString();
+    QString allReleaseController = settings->value(QString("DefaultAutoProfileAll/ReleaseController"), "0").toString();
 
     // Handle overall Default profile assignment
     bool defaultActive = allActive == "1" ? true : false;
@@ -362,6 +410,7 @@ void AutoProfileWatcher::syncProfileAssignment()
     {
         allDefaultInfo = new AutoProfileInfo("all", allProfile, defaultActive, 0, this);
         allDefaultInfo->setDefaultState(true);
+        allDefaultInfo->setReleaseController(allReleaseController == "1");
     }
 
     // Handle device specific Default profile assignments
@@ -374,6 +423,8 @@ void AutoProfileWatcher::syncProfileAssignment()
         QString partialTitle = settings->value(QString("DefaultAutoProfile-%1/PartialTitle").arg(uniqueID), "").toString();
         QString windowClass = settings->value(QString("DefaultAutoProfile-%1/WindowClass").arg(uniqueID), "").toString();
         QString windowName = settings->value(QString("DefaultAutoProfile-%1/WindowName").arg(uniqueID), "").toString();
+        QString releaseController =
+            settings->value(QString("DefaultAutoProfile-%1/ReleaseController").arg(uniqueID), "0").toString();
 
         // need to change when it's needed to add windowClass, title and partial name
         if (!uniqueID.isEmpty() && !profile.isEmpty())
@@ -388,6 +439,7 @@ void AutoProfileWatcher::syncProfileAssignment()
                 info->setWindowClass(windowClass);
                 info->setPartialState(partialTitle == "1" ? true : false);
                 info->setDefaultState(true);
+                info->setReleaseController(releaseController == "1");
                 defaultProfileAssignments.insert(uniqueID, info);
             }
         }
@@ -409,6 +461,7 @@ void AutoProfileWatcher::syncProfileAssignment()
         active = settings->value(QString("AutoProfile%1Active").arg(i), 0).toString();
         windowName = settings->value(QString("AutoProfile%1WindowName").arg(i), "").toString();
         QString partialTitle = settings->value(QString("AutoProfile%1PartialTitle").arg(i), 0).toString();
+        QString releaseController = settings->value(QString("AutoProfile%1ReleaseController").arg(i), "0").toString();
         bool partialTitleBool = partialTitle == "1" ? true : false;
 
 #ifdef Q_OS_UNIX
@@ -426,6 +479,7 @@ void AutoProfileWatcher::syncProfileAssignment()
             if (profileActive)
             {
                 AutoProfileInfo *info = new AutoProfileInfo(uniqueID, profile, profileActive, partialTitleBool, this);
+                info->setReleaseController(releaseController == "1");
 
                 if (!windowClass.isEmpty())
                 {
@@ -605,6 +659,12 @@ QList<AutoProfileInfo *> *AutoProfileWatcher::getCustomDefaults()
 AutoProfileInfo *AutoProfileWatcher::getDefaultAllProfile() { return allDefaultInfo; }
 
 bool AutoProfileWatcher::isUniqueIDLocked(QString uniqueID) { return getUniqeIDSetLocal().contains(uniqueID); }
+
+void AutoProfileWatcher::resetCurrentApplication()
+{
+    currentApplication.clear();
+    currentAppWindowTitle.clear();
+}
 
 QHash<QString, QList<AutoProfileInfo *>> const &AutoProfileWatcher::getAppProfileAssignments()
 {

--- a/src/autoprofilewatcher.h
+++ b/src/autoprofilewatcher.h
@@ -52,6 +52,7 @@ class AutoProfileWatcher : public QObject
     QHash<QString, QList<AutoProfileInfo *>> const &getWindowClassProfileAssignments();
     QHash<QString, QList<AutoProfileInfo *>> const &getWindowNameProfileAssignments();
     QHash<QString, AutoProfileInfo *> const &getDefaultProfileAssignments();
+    void resetCurrentApplication();
 
     static const int CHECKTIME = 500; // time in ms
 

--- a/src/gui/addeditautoprofiledialog.cpp
+++ b/src/gui/addeditautoprofiledialog.cpp
@@ -109,6 +109,7 @@ AddEditAutoProfileDialog::AddEditAutoProfileDialog(AutoProfileInfo *info, AntiMi
     ui->applicationLineEdit->setText(info->getExe());
     ui->winClassLineEdit->setText(info->getWindowClass());
     ui->winNameLineEdit->setText(info->getWindowName());
+    ui->releaseControllerCheckBox->setChecked(info->shouldReleaseController());
 #ifdef Q_OS_UNIX
     ui->selectWindowPushButton->setVisible(false);
 #elif defined(Q_OS_WIN)
@@ -127,6 +128,8 @@ AddEditAutoProfileDialog::AddEditAutoProfileDialog(AutoProfileInfo *info, AntiMi
             &AddEditAutoProfileDialog::checkForReservedUniques);
     connect(ui->devicesComboBox, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentTextChanged), this,
             &AddEditAutoProfileDialog::checkDefaultCheckbox);
+    connect(ui->releaseControllerCheckBox, &QCheckBox::toggled, this,
+            &AddEditAutoProfileDialog::updateReleaseControllerControlState);
     connect(ui->applicationLineEdit, &QLineEdit::textChanged, this, &AddEditAutoProfileDialog::checkForDefaultStatus);
     connect(ui->winClassLineEdit, &QLineEdit::textChanged, this, &AddEditAutoProfileDialog::checkForDefaultStatus);
     connect(ui->winNameLineEdit, &QLineEdit::textChanged, this, &AddEditAutoProfileDialog::checkForDefaultStatus);
@@ -139,6 +142,7 @@ AddEditAutoProfileDialog::AddEditAutoProfileDialog(AutoProfileInfo *info, AntiMi
     connect(this, &AddEditAutoProfileDialog::accepted, this, &AddEditAutoProfileDialog::saveAutoProfileInformation);
 
     ui->asDefaultCheckBox->setChecked(info->isCurrentDefault());
+    updateReleaseControllerControlState();
 }
 
 // created for tests
@@ -204,6 +208,7 @@ void AddEditAutoProfileDialog::saveAutoProfileInformation()
     info->setWindowName(ui->winNameLineEdit->text());
     info->setDefaultState(ui->asDefaultCheckBox->isChecked());
     info->setPartialState(ui->setPartialCheckBox->isChecked());
+    info->setReleaseController(ui->releaseControllerCheckBox->isChecked());
 }
 
 void AddEditAutoProfileDialog::checkForReservedUniques(int index)
@@ -226,6 +231,29 @@ void AddEditAutoProfileDialog::checkForReservedUniques(int index)
         ui->asDefaultCheckBox->setEnabled(true);
         QMessageBox::information(this, tr("Chosen Profile"),
                                  tr("The selection will be used instead\nof the all default profile option."));
+    }
+
+    updateReleaseControllerControlState();
+}
+
+void AddEditAutoProfileDialog::updateReleaseControllerControlState()
+{
+    bool releaseController = ui->releaseControllerCheckBox->isChecked();
+    ui->profileLineEdit->setEnabled(!releaseController);
+    ui->profileBrowsePushButton->setEnabled(!releaseController);
+
+    if (releaseController)
+    {
+        ui->asDefaultCheckBox->setEnabled(false);
+    } else
+    {
+        bool hasWindowRule = !ui->applicationLineEdit->text().isEmpty() || !ui->winClassLineEdit->text().isEmpty() ||
+                             !ui->winNameLineEdit->text().isEmpty();
+        QVariant data = ui->devicesComboBox->itemData(ui->devicesComboBox->currentIndex());
+        bool reservedDevice =
+            !data.isNull() && getReservedUniques().contains(data.value<InputDevice *>()->getUniqueIDString());
+
+        ui->asDefaultCheckBox->setEnabled(ui->devicesComboBox->currentText() != "all" && !hasWindowRule && !reservedDevice);
     }
 }
 
@@ -383,6 +411,9 @@ void AddEditAutoProfileDialog::checkForDefaultStatus()
     {
         ui->asDefaultCheckBox->setEnabled(true);
     }
+
+    if (ui->releaseControllerCheckBox->isChecked())
+        ui->asDefaultCheckBox->setEnabled(false);
 }
 
 /**
@@ -390,6 +421,9 @@ void AddEditAutoProfileDialog::checkForDefaultStatus()
  */
 void AddEditAutoProfileDialog::check_profile_file()
 {
+    if (ui->releaseControllerCheckBox->isChecked())
+        return;
+
     if (ui->profileLineEdit->text().length() > 0)
     {
         QFileInfo profileFileName(ui->profileLineEdit->text());
@@ -471,6 +505,8 @@ void AddEditAutoProfileDialog::checkDefaultCheckbox(const QString &text)
     {
         ui->asDefaultCheckBox->setDisabled(false);
     }
+
+    updateReleaseControllerControlState();
 }
 
 #ifdef Q_OS_WIN

--- a/src/gui/addeditautoprofiledialog.h
+++ b/src/gui/addeditautoprofiledialog.h
@@ -69,6 +69,7 @@ class AddEditAutoProfileDialog : public QDialog
     void openApplicationBrowseDialog();
     void saveAutoProfileInformation();
     void checkForReservedUniques(int index);
+    void updateReleaseControllerControlState();
     void checkForDefaultStatus();
     void windowPropAssignment(CapturedWindowInfoDialog *dialog);
     void checkDefaultCheckbox(const QString &text);

--- a/src/gui/addeditautoprofiledialog.ui
+++ b/src/gui/addeditautoprofiledialog.ui
@@ -185,6 +185,16 @@ of the all default profile option.</string>
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="releaseControllerCheckBox">
+       <property name="toolTip">
+        <string>Allows the focused application to receive selected gamepad input directly until AntiMicroX is focused again or another auto profile is selected.</string>
+       </property>
+       <property name="text">
+        <string>Release gamepad(s) while this profile is active</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/gui/editalldefaultautoprofiledialog.cpp
+++ b/src/gui/editalldefaultautoprofiledialog.cpp
@@ -43,10 +43,16 @@ EditAllDefaultAutoProfileDialog::EditAllDefaultAutoProfileDialog(AutoProfileInfo
     if (!info->getProfileLocation().isEmpty())
         ui->profileLineEdit->setText(info->getProfileLocation());
 
+    ui->releaseControllerCheckBox->setChecked(info->shouldReleaseController());
+
     connect(ui->profileBrowsePushButton, &QPushButton::clicked, this,
             &EditAllDefaultAutoProfileDialog::openProfileBrowseDialog);
+    connect(ui->releaseControllerCheckBox, &QCheckBox::toggled, this,
+            &EditAllDefaultAutoProfileDialog::updateReleaseControllerControlState);
     connect(this, &EditAllDefaultAutoProfileDialog::accepted, this,
             &EditAllDefaultAutoProfileDialog::saveAutoProfileInformation);
+
+    updateReleaseControllerControlState();
 }
 
 EditAllDefaultAutoProfileDialog::~EditAllDefaultAutoProfileDialog() { delete ui; }
@@ -66,6 +72,14 @@ void EditAllDefaultAutoProfileDialog::saveAutoProfileInformation()
     info->setUniqueID("all");
     info->setProfileLocation(ui->profileLineEdit->text());
     info->setActive(true);
+    info->setReleaseController(ui->releaseControllerCheckBox->isChecked());
+}
+
+void EditAllDefaultAutoProfileDialog::updateReleaseControllerControlState()
+{
+    bool releaseController = ui->releaseControllerCheckBox->isChecked();
+    ui->profileLineEdit->setEnabled(!releaseController);
+    ui->profileBrowsePushButton->setEnabled(!releaseController);
 }
 
 AutoProfileInfo *EditAllDefaultAutoProfileDialog::getAutoProfile() const { return info; }
@@ -75,7 +89,7 @@ void EditAllDefaultAutoProfileDialog::accept()
     bool validForm = true;
     QString errorString = QString();
 
-    if (ui->profileLineEdit->text().length() > 0)
+    if (!ui->releaseControllerCheckBox->isChecked() && ui->profileLineEdit->text().length() > 0)
     {
         QFileInfo profileInfo(ui->profileLineEdit->text());
 

--- a/src/gui/editalldefaultautoprofiledialog.h
+++ b/src/gui/editalldefaultautoprofiledialog.h
@@ -52,6 +52,7 @@ class EditAllDefaultAutoProfileDialog : public QDialog
   private slots:
     void openProfileBrowseDialog();
     void saveAutoProfileInformation();
+    void updateReleaseControllerControlState();
 };
 
 #endif // EDITALLDEFAULTAUTOPROFILEDIALOG_H

--- a/src/gui/editalldefaultautoprofiledialog.ui
+++ b/src/gui/editalldefaultautoprofiledialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>384</width>
-    <height>114</height>
+    <height>142</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -56,6 +56,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="releaseControllerCheckBox">
+     <property name="toolTip">
+      <string>Allows the focused application to receive gamepad input directly. AntiMicroX will stop loading profiles for all devices until AntiMicroX is focused again or another auto profile is selected.</string>
+     </property>
+     <property name="text">
+      <string>Release all gamepads while this default profile is active</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/gui/mainsettingsdialog.cpp
+++ b/src/gui/mainsettingsdialog.cpp
@@ -821,11 +821,13 @@ void MainSettingsDialog::populateAutoProfiles()
     QString allProfile = settings->value(QString("DefaultAutoProfileAll/Profile"), "all").toString();
     QString allActive = settings->value(QString("DefaultAutoProfileAll/Active"), "0").toString();
     QString partialTitle = settings->value(QString("DefaultAutoProfileAll/PartialTitle"), "").toString();
+    QString allReleaseController = settings->value(QString("DefaultAutoProfileAll/ReleaseController"), "0").toString();
 
     bool defaultActive = allActive == "1" ? true : false;
     bool partialTitleBool = partialTitle == "1" ? true : false;
     allDefaultProfile = new AutoProfileInfo("all", allProfile, defaultActive, partialTitleBool, this);
     allDefaultProfile->setDefaultState(true);
+    allDefaultProfile->setReleaseController(allReleaseController == "1");
 
     QStringListIterator iter(registeredGUIDs);
     while (iter.hasNext())
@@ -840,6 +842,8 @@ void MainSettingsDialog::populateAutoProfiles()
         QString windowClass = settings->value(QString("DefaultAutoProfile-%1/WindowClass").arg(guid), "").toString();
         QString windowName = settings->value(QString("DefaultAutoProfile-%1/WindowName").arg(guid), "").toString();
         QString exe = settings->value(QString("DefaultAutoProfile-%1/Exe").arg(guid), "").toString();
+        QString releaseController =
+            settings->value(QString("DefaultAutoProfile-%1/ReleaseController").arg(guid), "0").toString();
 
         if (!guid.isEmpty() && !profile.isEmpty() && !deviceName.isEmpty())
         {
@@ -852,6 +856,7 @@ void MainSettingsDialog::populateAutoProfiles()
                 info->setExe(exe);
                 info->setWindowName(windowName);
                 info->setWindowClass(windowClass);
+                info->setReleaseController(releaseController == "1");
                 defaultAutoProfiles.insert(guid, info);
                 defaultList.append(info);
                 QList<AutoProfileInfo *> templist;
@@ -880,6 +885,7 @@ void MainSettingsDialog::populateAutoProfiles()
         QString partialTitle = settings->value(QString("AutoProfile%1PartialTitle").arg(i), 0).toString();
         bool partialTitleBool = partialTitle == "1" ? true : false;
         QString deviceName = settings->value(QString("AutoProfile%1DeviceName").arg(i), "").toString();
+        QString releaseController = settings->value(QString("AutoProfile%1ReleaseController").arg(i), "0").toString();
 
         // Check if all required elements exist. If not, assume that the end of the
         // list has been reached.
@@ -887,6 +893,7 @@ void MainSettingsDialog::populateAutoProfiles()
         {
             bool profileActive = active == "1" ? true : false;
             AutoProfileInfo *info = new AutoProfileInfo(guid, profile, exe, profileActive, partialTitleBool, this);
+            info->setReleaseController(releaseController == "1");
             if (!deviceName.isEmpty())
             {
                 info->setDeviceName(deviceName);
@@ -1145,6 +1152,8 @@ void MainSettingsDialog::saveAutoProfileSettings()
         QString defaultActive = allDefaultProfile->isActive() ? "1" : "0";
         settings->setValue(QString("DefaultAutoProfileAll/Profile"), profile);
         settings->setValue(QString("DefaultAutoProfileAll/Active"), defaultActive);
+        if (allDefaultProfile->shouldReleaseController())
+            settings->setValue(QString("DefaultAutoProfileAll/ReleaseController"), "1");
     }
 
     QMapIterator<QString, AutoProfileInfo *> iter(defaultAutoProfiles);
@@ -1165,6 +1174,8 @@ void MainSettingsDialog::saveAutoProfileSettings()
         settings->setValue(QString("DefaultAutoProfile-%1/WindowClass").arg(guid), info->getWindowClass());
         settings->setValue(QString("DefaultAutoProfile-%1/Exe").arg(guid), info->getExe());
         settings->setValue(QString("DefaultAutoProfile-%1/PartialTitle").arg(guid), 0);
+        if (info->shouldReleaseController())
+            settings->setValue(QString("DefaultAutoProfile-%1/ReleaseController").arg(guid), "1");
     }
 
     if (!registeredGUIDs.isEmpty())
@@ -1204,6 +1215,8 @@ void MainSettingsDialog::saveAutoProfileSettings()
         settings->setValue(QString("AutoProfile%1Active").arg(i), defaultActive);
         settings->setValue(QString("AutoProfile%1PartialTitle").arg(i), partialTitle);
         settings->setValue(QString("AutoProfile%1DeviceName").arg(i), info->getDeviceName());
+        if (info->shouldReleaseController())
+            settings->setValue(QString("AutoProfile%1ReleaseController").arg(i), "1");
         i++;
     }
     settings->endGroup();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -122,6 +122,8 @@ MainWindow::MainWindow(QMap<SDL_JoystickID, InputDevice *> *joysticks, CommandLi
 #endif
 
     signalDisconnect = false;
+    inputCaptureSuspendedByAutoProfile = false;
+    allInputCaptureSuspendedByAutoProfile = false;
     showTrayIcon = !cmdutility->isTrayHidden() && graphical && !cmdutility->shouldListControllers();
 
     m_joysticks = joysticks;
@@ -985,6 +987,9 @@ void MainWindow::changeEvent(QEvent *event)
     } else if (event->type() == QEvent::LanguageChange)
     {
         retranslateUi();
+    } else if (event->type() == QEvent::ActivationChange && isActiveWindow())
+    {
+        resumeInputCaptureIfSuspended();
     }
 
     QMainWindow::changeEvent(event);
@@ -1459,7 +1464,7 @@ void MainWindow::testMappingUpdateNow(int index, InputDevice *device)
     }
 }
 
-void MainWindow::removeJoyTab(SDL_JoystickID deviceID)
+void MainWindow::removeJoyTab(SDL_JoystickID deviceID, bool saveDeviceSettings)
 {
     bool found = false;
     for (int i = 0; (i < ui->tabWidget->count()) && !found; i++)
@@ -1468,7 +1473,8 @@ void MainWindow::removeJoyTab(SDL_JoystickID deviceID)
         if ((tab != nullptr) && (deviceID == tab->getJoystick()->getSDLJoystickID()))
         {
             // Save most recent profile list to settings before removing tab.
-            tab->saveDeviceSettings();
+            if (saveDeviceSettings)
+                tab->saveDeviceSettings();
 
             // Remove flash event connections between buttons and
             // the tab before deleting tab.
@@ -1540,12 +1546,97 @@ void MainWindow::addJoyTab(InputDevice *device)
 
 void MainWindow::autoprofileLoad(AutoProfileInfo *info)
 {
+    if (info == nullptr)
+    {
+        loadAutoProfileWithExistingLogic(info);
+        return;
+    }
+
+    if (!info->shouldReleaseController())
+    {
+        if (!inputCaptureSuspendedByAutoProfile)
+        {
+            loadAutoProfileWithExistingLogic(info);
+            return;
+        }
+
+        if (!isAutoProfileBlockedBySuspendedInputCapture(info))
+        {
+            loadAutoProfileWithExistingLogic(info, inputCaptureSuspendedUniqueIDs);
+            return;
+        }
+
+        pendingAutoProfileAfterResume = info;
+        clearAutoProfileInputCaptureSuspension();
+        emit inputCaptureResumeRequested();
+        return;
+    }
+
+    const QString releaseInputCaptureUniqueID = info->getUniqueID();
+
+    if (releaseInputCaptureUniqueID == "all")
+    {
+        bool requestAllInputCaptureSuspend = !allInputCaptureSuspendedByAutoProfile;
+
+        inputCaptureSuspendedByAutoProfile = true;
+        allInputCaptureSuspendedByAutoProfile = true;
+        inputCaptureSuspendedUniqueIDs.clear();
+        pendingAutoProfileAfterResume = nullptr;
+
+        if (requestAllInputCaptureSuspend)
+        {
+            removeJoyTabs();
+            ui->stackedWidget->setCurrentIndex(0);
+            ui->actionUpdate_Joysticks->setEnabled(false);
+            emit inputCaptureSuspendRequested(releaseInputCaptureUniqueID);
+        }
+
+        return;
+    }
+
+    if (allInputCaptureSuspendedByAutoProfile || inputCaptureSuspendedUniqueIDs.contains(releaseInputCaptureUniqueID))
+    {
+        pendingAutoProfileAfterResume = nullptr;
+        return;
+    }
+
+    inputCaptureSuspendedByAutoProfile = true;
+    inputCaptureSuspendedUniqueIDs.insert(releaseInputCaptureUniqueID);
+    pendingAutoProfileAfterResume = nullptr;
+    ui->actionUpdate_Joysticks->setEnabled(false);
+    emit inputCaptureSuspendRequested(releaseInputCaptureUniqueID);
+}
+
+bool MainWindow::isAutoProfileBlockedBySuspendedInputCapture(AutoProfileInfo *info) const
+{
+    if (info == nullptr || !inputCaptureSuspendedByAutoProfile)
+        return false;
+
+    if (allInputCaptureSuspendedByAutoProfile)
+        return true;
+
+    if (info->getUniqueID() == "all")
+        return !inputCaptureSuspendedUniqueIDs.isEmpty();
+
+    return inputCaptureSuspendedUniqueIDs.contains(info->getUniqueID());
+}
+
+void MainWindow::clearAutoProfileInputCaptureSuspension()
+{
+    inputCaptureSuspendedByAutoProfile = false;
+    allInputCaptureSuspendedByAutoProfile = false;
+    inputCaptureSuspendedUniqueIDs.clear();
+}
+
+void MainWindow::loadAutoProfileWithExistingLogic(AutoProfileInfo *info, const QSet<QString> &skipUniqueIDs)
+{
     if (info != nullptr)
     {
         qDebug() << QString("Auto-switching to profile \"%1\".").arg(info->getProfileLocation());
     } else
     {
         qCritical() << QString("Auto-switching to nullptr profile!");
+        return;
     }
 #if defined(WITH_X11) || defined(Q_OS_WIN)
     #if defined(WITH_X11)
@@ -1562,6 +1653,14 @@ void MainWindow::autoprofileLoad(AutoProfileInfo *info)
             // if (info->getGUID() == "all")
             if (info->getUniqueID() == "all")
             {
+                InputDevice *joystick = widget->getJoystick();
+                if (joystick != nullptr &&
+                    (skipUniqueIDs.contains(joystick->getUniqueIDString()) ||
+                     skipUniqueIDs.contains(joystick->getStringIdentifier())))
+                {
+                    continue;
+                }
+
                 // If the all option for a Default profile was found,
                 // first check for controller specific associations. If one exists,
                 // skip changing the profile on the controller. A later call will
@@ -1640,6 +1739,32 @@ void MainWindow::autoprofileLoad(AutoProfileInfo *info)
     }
 
 #endif
+}
+
+void MainWindow::resumeInputCaptureIfSuspended()
+{
+    if (!inputCaptureSuspendedByAutoProfile)
+        return;
+
+    inputCaptureSuspendedByAutoProfile = false;
+    allInputCaptureSuspendedByAutoProfile = false;
+    inputCaptureSuspendedUniqueIDs.clear();
+    pendingAutoProfileAfterResume = nullptr;
+
+    if (appWatcher != nullptr)
+        appWatcher->resetCurrentApplication();
+
+    emit inputCaptureResumeRequested();
+}
+
+void MainWindow::completePendingAutoProfileLoad()
+{
+    if (pendingAutoProfileAfterResume)
+    {
+        loadAutoProfileWithExistingLogic(pendingAutoProfileAfterResume);
+    }
+
+    pendingAutoProfileAfterResume = nullptr;
 }
 
 void MainWindow::checkAutoProfileWatcherTimer()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1654,9 +1654,8 @@ void MainWindow::loadAutoProfileWithExistingLogic(AutoProfileInfo *info, const Q
             if (info->getUniqueID() == "all")
             {
                 InputDevice *joystick = widget->getJoystick();
-                if (joystick != nullptr &&
-                    (skipUniqueIDs.contains(joystick->getUniqueIDString()) ||
-                     skipUniqueIDs.contains(joystick->getStringIdentifier())))
+                if (joystick != nullptr && (skipUniqueIDs.contains(joystick->getUniqueIDString()) ||
+                                            skipUniqueIDs.contains(joystick->getStringIdentifier())))
                 {
                     continue;
                 }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -23,6 +23,8 @@
 
 #include <QMainWindow>
 #include <QMap>
+#include <QPointer>
+#include <QSet>
 #include <QSystemTrayIcon>
 
 #ifdef CHECK_FOR_UPDATES
@@ -91,6 +93,8 @@ class MainWindow : public QMainWindow
     void joystickRefreshRequested();
     void readConfig(int index); // MainConfiguration class
     void mappingUpdated(QString mapping, InputDevice *device);
+    void inputCaptureSuspendRequested(QString uniqueID);
+    void inputCaptureResumeRequested();
 
   public slots:
     void checkEachTenMinutesBattery(QMap<SDL_JoystickID, InputDevice *> *joysticks);
@@ -108,10 +112,11 @@ class MainWindow : public QMainWindow
     void changeWindowStatus();
     void refreshTabHelperThreads();
     void testMappingUpdateNow(int index, InputDevice *device);
-    void removeJoyTab(SDL_JoystickID deviceID);
+    void removeJoyTab(SDL_JoystickID deviceID, bool saveDeviceSettings = true);
     void addJoyTab(InputDevice *device);
     void selectControllerJoyTab(QString GUID);
     void handleInstanceDisconnect();
+    void completePendingAutoProfileLoad();
 
   private slots:
     void refreshTrayIconMenu();
@@ -151,6 +156,10 @@ class MainWindow : public QMainWindow
      * @brief Check state of batteries in controllers and notify user (only when powerLevSDL matches current battery level)
      */
     void showBatteryLevel(SDL_JoystickPowerLevel powerLevSDL, QString batteryLev, QString percent, InputDevice *device);
+    bool isAutoProfileBlockedBySuspendedInputCapture(AutoProfileInfo *info) const;
+    void clearAutoProfileInputCaptureSuspension();
+    void loadAutoProfileWithExistingLogic(AutoProfileInfo *info, const QSet<QString> &skipUniqueIDs = QSet<QString>());
+    void resumeInputCaptureIfSuspended();
 
     Ui::MainWindow *ui;
 
@@ -174,6 +183,10 @@ class MainWindow : public QMainWindow
     bool signalDisconnect;
     bool showTrayIcon;
     bool m_graphical;
+    bool inputCaptureSuspendedByAutoProfile;
+    bool allInputCaptureSuspendedByAutoProfile;
+    QSet<QString> inputCaptureSuspendedUniqueIDs;
+    QPointer<AutoProfileInfo> pendingAutoProfileAfterResume;
 
 #ifdef CHECK_FOR_UPDATES
     QNetworkAccessManager m_network_manager; // Used for checking updates

--- a/src/inputdaemon.cpp
+++ b/src/inputdaemon.cpp
@@ -46,6 +46,8 @@ InputDaemon::InputDaemon(QMap<SDL_JoystickID, InputDevice *> *joysticks, AntiMic
     this->stopped = false;
     m_graphical = graphical;
     m_settings = settings;
+    m_inputCaptureSuspended = false;
+    m_allInputCaptureSuspended = false;
 
     eventWorker = new SDLEventReader(joysticks, settings);
     refreshJoysticks();
@@ -101,6 +103,12 @@ void InputDaemon::startWorker()
 void InputDaemon::run()
 {
     PadderCommon::inputDaemonMutex.lock();
+
+    if (m_allInputCaptureSuspended)
+    {
+        PadderCommon::inputDaemonMutex.unlock();
+        return;
+    }
 
     // SDL has found events. The timeout is not necessary.
     pollResetTimer.stop();
@@ -264,6 +272,9 @@ void InputDaemon::stop()
 
 void InputDaemon::refresh()
 {
+    if (m_inputCaptureSuspended)
+        return;
+
     qDebug() << "REFRESH";
 
     stop();
@@ -293,6 +304,144 @@ void InputDaemon::refresh()
 
     stopped = false;
 }
+
+void InputDaemon::suspendInputCapture(QString uniqueID)
+{
+    if (eventWorker == nullptr || uniqueID.isEmpty())
+        return;
+
+    if (m_allInputCaptureSuspended || (uniqueID != "all" && m_suspendedCaptureUniqueIDs.contains(uniqueID)))
+        return;
+
+    stopped = true;
+    pollResetTimer.stop();
+    bool suspended = false;
+
+    if (uniqueID == "all")
+    {
+        for (InputDevice *device : *m_joysticks)
+        {
+            if (device != nullptr && device->getActiveSetJoystick() != nullptr)
+                device->getActiveSetJoystick()->release();
+        }
+
+        if (eventWorker->isSDLOpen())
+        {
+            if (m_graphical)
+            {
+                QEventLoop q;
+                connect(eventWorker, &SDLEventReader::sdlClosed, &q, &QEventLoop::quit);
+                QMetaObject::invokeMethod(eventWorker, "suspend");
+                q.exec();
+                disconnect(eventWorker, &SDLEventReader::sdlClosed, &q, &QEventLoop::quit);
+            } else
+            {
+                eventWorker->suspend();
+            }
+        }
+
+        QMapIterator<SDL_JoystickID, InputDevice *> iter(*m_joysticks);
+        while (iter.hasNext())
+        {
+            InputDevice *joystick = iter.next().value();
+
+            if (joystick != nullptr)
+                joystick->deleteLater();
+        }
+
+        m_joysticks->clear();
+        getTrackjoysticksLocal().clear();
+        trackcontrollers.clear();
+        clearBitArrayStatusInstances();
+        m_allInputCaptureSuspended = true;
+        m_suspendedCaptureUniqueIDs.clear();
+        suspended = true;
+    } else
+    {
+        InputDevice *targetDevice = nullptr;
+        QMapIterator<SDL_JoystickID, InputDevice *> iter(*m_joysticks);
+
+        while (iter.hasNext() && targetDevice == nullptr)
+        {
+            InputDevice *device = iter.next().value();
+            if (device != nullptr &&
+                (device->getUniqueIDString() == uniqueID || device->getStringIdentifier() == uniqueID))
+            {
+                targetDevice = device;
+            }
+        }
+
+        if (targetDevice != nullptr)
+        {
+            if (targetDevice->getActiveSetJoystick() != nullptr)
+                targetDevice->getActiveSetJoystick()->release();
+
+            m_suspendedCaptureUniqueIDs.insert(uniqueID);
+            removeDevice(targetDevice, false);
+            suspended = true;
+        }
+    }
+
+    if (!suspended)
+    {
+        stopped = false;
+        return;
+    }
+
+    m_inputCaptureSuspended = true;
+    stopped = false;
+
+    emit inputCaptureSuspended();
+}
+
+void InputDaemon::resumeInputCapture()
+{
+    if (!m_inputCaptureSuspended || eventWorker == nullptr)
+        return;
+
+    stopped = true;
+    pollResetTimer.stop();
+    m_inputCaptureSuspended = false;
+    m_allInputCaptureSuspended = false;
+    m_suspendedCaptureUniqueIDs.clear();
+
+    if (eventWorker->isSDLOpen())
+    {
+        if (m_graphical)
+        {
+            QEventLoop q;
+            connect(eventWorker, &SDLEventReader::sdlStarted, &q, &QEventLoop::quit);
+            QMetaObject::invokeMethod(eventWorker, "refresh");
+            q.exec();
+            disconnect(eventWorker, &SDLEventReader::sdlStarted, &q, &QEventLoop::quit);
+        } else
+        {
+            eventWorker->refresh();
+        }
+    } else
+    {
+        if (m_graphical)
+        {
+            QEventLoop q;
+            connect(eventWorker, &SDLEventReader::sdlStarted, &q, &QEventLoop::quit);
+            QMetaObject::invokeMethod(eventWorker, "resume");
+            q.exec();
+            disconnect(eventWorker, &SDLEventReader::sdlStarted, &q, &QEventLoop::quit);
+        } else
+        {
+            eventWorker->resume();
+        }
+    }
+
+    refreshJoysticks();
+    QTimer::singleShot(100, eventWorker, SLOT(performWork()));
+
+    stopped = false;
+
+    emit inputCaptureResumed();
+}
+
+bool InputDaemon::isInputCaptureSuspended() const { return m_inputCaptureSuspended; }
 
 void InputDaemon::refreshJoystick(InputDevice *joystick)
 {
@@ -400,11 +549,13 @@ void InputDaemon::refreshMapping(QString mapping, InputDevice *device)
     }
 }
 
-void InputDaemon::removeDevice(InputDevice *device)
+void InputDaemon::removeDevice(InputDevice *device, bool saveDeviceSettings)
 {
     if (device != nullptr)
     {
         SDL_JoystickID deviceID = device->getSDLJoystickID();
+
+        clearBitArrayStatusInstances(device);
 
         m_joysticks->remove(deviceID);
         getTrackjoysticksLocal().remove(deviceID);
@@ -412,7 +563,8 @@ void InputDaemon::removeDevice(InputDevice *device)
 
         refreshIndexes();
 
-        emit deviceRemoved(deviceID);
+        emit deviceRemoved(deviceID, saveDeviceSettings);
+        device->closeSDLDevice();
     }
 }
 
@@ -465,14 +617,20 @@ void InputDaemon::addInputDevice(int index, QMap<QString, int> &uniques, int &co
                 if (!disableGameController)
                 {
                     GameController *damncontroller = new GameController(controller, index, m_settings, this);
-                    connect(damncontroller, &GameController::requestWait, eventWorker, &SDLEventReader::haltServices);
-                    m_joysticks->insert(tempJoystickID, damncontroller);
-                    trackcontrollers.insert(tempJoystickID, damncontroller);
+                    if (isInputDeviceCaptureSuspended(damncontroller))
+                    {
+                        discardInputDevice(damncontroller);
+                    } else
+                    {
+                        connect(damncontroller, &GameController::requestWait, eventWorker, &SDLEventReader::haltServices);
+                        m_joysticks->insert(tempJoystickID, damncontroller);
+                        trackcontrollers.insert(tempJoystickID, damncontroller);
 
-                    qInfo() << QString("New game controller found - #%1 [%2]".arg(index + 1).arg(
-                        QTime::currentTime().toString("hh:mm:ss.zzz")));
+                        qInfo() << QString("New game controller found - #%1 [%2]".arg(index + 1).arg(
+                            QTime::currentTime().toString("hh:mm:ss.zzz")));
 
-                    emit deviceAdded(damncontroller);
+                        emit deviceAdded(damncontroller);
+                    }
                 } else
                 {
                     // Check if joystick is considered connected.
@@ -480,10 +638,16 @@ void InputDaemon::addInputDevice(int index, QMap<QString, int> &uniques, int &co
                     Joystick *joystick = openJoystickDevice(index);
                     if (joystick != nullptr)
                     {
-                        qInfo() << QString("New joystick found - #%1 [%2]".arg(index + 1).arg(
-                            QTime::currentTime().toString("hh:mm:ss.zzz")));
+                        if (isInputDeviceCaptureSuspended(joystick))
+                        {
+                            discardInputDevice(joystick);
+                        } else
+                        {
+                            qInfo() << QString("New joystick found - #%1 [%2]".arg(index + 1).arg(
+                                QTime::currentTime().toString("hh:mm:ss.zzz")));
 
-                        emit deviceAdded(joystick);
+                            emit deviceAdded(joystick);
+                        }
                     }
                 }
             } else
@@ -497,10 +661,17 @@ void InputDaemon::addInputDevice(int index, QMap<QString, int> &uniques, int &co
         Joystick *joystick = openJoystickDevice(index);
         if (joystick != nullptr)
         {
-            Logger::LogInfo(
-                QString("New joystick found - #%1 [%2]").arg(index + 1).arg(QTime::currentTime().toString("hh:mm:ss.zzz")));
+            if (isInputDeviceCaptureSuspended(joystick))
+            {
+                discardInputDevice(joystick);
+            } else
+            {
+                Logger::LogInfo(QString("New joystick found - #%1 [%2]")
+                                    .arg(index + 1)
+                                    .arg(QTime::currentTime().toString("hh:mm:ss.zzz")));
 
-            emit deviceAdded(joystick);
+                emit deviceAdded(joystick);
+            }
         }
     }
 #else
@@ -591,14 +762,26 @@ void InputDaemon::addInputDevice(int index, QMap<QString, int> &uniques, int &co
                     {
                         GameController *damncontroller =
                             new GameController(controller, index, m_settings, resultDuplicated, this);
-                        connect(damncontroller, &GameController::requestWait, eventWorker, &SDLEventReader::haltServices);
-                        m_joysticks->insert(tempJoystickID_local_2, damncontroller);
-                        trackcontrollers.insert(tempJoystickID_local_2, damncontroller);
-
                         m_settings->endGroup();
                         m_settings->getLock()->unlock();
 
-                        emit deviceAdded(damncontroller);
+                        if (isInputDeviceCaptureSuspended(damncontroller))
+                        {
+                            discardInputDevice(damncontroller);
+                        } else
+                        {
+                            connect(damncontroller, &GameController::requestWait, eventWorker,
+                                    &SDLEventReader::haltServices);
+                            m_joysticks->insert(tempJoystickID_local_2, damncontroller);
+                            trackcontrollers.insert(tempJoystickID_local_2, damncontroller);
+
+                            emit deviceAdded(damncontroller);
+                        }
+                    } else
+                    {
+                        SDL_GameControllerClose(controller);
+                        m_settings->endGroup();
+                        m_settings->getLock()->unlock();
                     }
 
                     duplicatedGamepad = false;
@@ -610,13 +793,19 @@ void InputDaemon::addInputDevice(int index, QMap<QString, int> &uniques, int &co
             } else
             {
                 Joystick *curJoystick = new Joystick(joystick, index, m_settings, this);
-                m_joysticks->insert(tempJoystickID_local, curJoystick);
-                getTrackjoysticksLocal().insert(tempJoystickID_local, curJoystick);
-
                 m_settings->endGroup();
                 m_settings->getLock()->unlock();
 
-                emit deviceAdded(curJoystick);
+                if (isInputDeviceCaptureSuspended(curJoystick))
+                {
+                    discardInputDevice(curJoystick);
+                } else
+                {
+                    m_joysticks->insert(tempJoystickID_local, curJoystick);
+                    getTrackjoysticksLocal().insert(tempJoystickID_local, curJoystick);
+
+                    emit deviceAdded(curJoystick);
+                }
             }
         } else
         {
@@ -1270,6 +1459,44 @@ void InputDaemon::clearBitArrayStatusInstances()
     }
 
     getPendingEventValuesLocal().clear();
+}
+
+void InputDaemon::clearBitArrayStatusInstances(InputDevice *device)
+{
+    if (device == nullptr)
+        return;
+
+    InputDeviceBitArrayStatus *releaseStatus = getReleaseEventsGeneratedLocal().take(device);
+    if (releaseStatus != nullptr)
+        releaseStatus->deleteLater();
+
+    InputDeviceBitArrayStatus *pendingStatus = getPendingEventValuesLocal().take(device);
+    if (pendingStatus != nullptr)
+        pendingStatus->deleteLater();
+}
+
+bool InputDaemon::isInputDeviceCaptureSuspended(InputDevice *device) const
+{
+    if (!m_inputCaptureSuspended || m_allInputCaptureSuspended || device == nullptr)
+        return false;
+
+    return m_suspendedCaptureUniqueIDs.contains(device->getUniqueIDString()) ||
+           m_suspendedCaptureUniqueIDs.contains(device->getStringIdentifier());
+}
+
+void InputDaemon::discardInputDevice(InputDevice *device)
+{
+    if (device == nullptr)
+        return;
+
+    SDL_JoystickID deviceID = device->getSDLJoystickID();
+
+    clearBitArrayStatusInstances(device);
+    m_joysticks->remove(deviceID);
+    getTrackjoysticksLocal().remove(deviceID);
+    trackcontrollers.remove(deviceID);
+    device->closeSDLDevice();
+    device->deleteLater();
 }
 
 void InputDaemon::resetActiveButtonMouseDistances()

--- a/src/inputdaemon.cpp
+++ b/src/inputdaemon.cpp
@@ -364,8 +364,7 @@ void InputDaemon::suspendInputCapture(QString uniqueID)
         while (iter.hasNext() && targetDevice == nullptr)
         {
             InputDevice *device = iter.next().value();
-            if (device != nullptr &&
-                (device->getUniqueIDString() == uniqueID || device->getStringIdentifier() == uniqueID))
+            if (device != nullptr && (device->getUniqueIDString() == uniqueID || device->getStringIdentifier() == uniqueID))
             {
                 targetDevice = device;
             }

--- a/src/inputdaemon.h
+++ b/src/inputdaemon.h
@@ -20,7 +20,7 @@
 #define INPUTDAEMONTHREAD_H
 
 #include "gamecontroller/gamecontroller.h"
-//#include "fakeclasses/xbox360wireless.h"
+// #include "fakeclasses/xbox360wireless.h"
 #include <SDL2/SDL_events.h>
 
 #include <QSet>

--- a/src/inputdaemon.h
+++ b/src/inputdaemon.h
@@ -23,6 +23,8 @@
 //#include "fakeclasses/xbox360wireless.h"
 #include <SDL2/SDL_events.h>
 
+#include <QSet>
+
 class InputDevice;
 class AntiMicroSettings;
 class InputDeviceBitArrayStatus;
@@ -59,7 +61,10 @@ class InputDaemon : public QObject
     Joystick *openJoystickDevice(int index);
 
     void clearBitArrayStatusInstances();
+    void clearBitArrayStatusInstances(InputDevice *device);
     void convertMappingsToUnique(QSettings *sett, QString guidString, QString uniqueIdString);
+    bool isInputDeviceCaptureSuspended(InputDevice *device) const;
+    void discardInputDevice(InputDevice *device);
 
   signals:
     void joystickRefreshed(InputDevice *joystick);
@@ -68,8 +73,10 @@ class InputDaemon : public QObject
     void complete();
 
     void deviceUpdated(int index, InputDevice *device);
-    void deviceRemoved(SDL_JoystickID deviceID);
+    void deviceRemoved(SDL_JoystickID deviceID, bool saveDeviceSettings);
     void deviceAdded(InputDevice *device);
+    void inputCaptureSuspended();
+    void inputCaptureResumed();
 
   public slots:
     void run();
@@ -79,9 +86,12 @@ class InputDaemon : public QObject
     void refreshJoysticks();
     void startWorker();
     void refreshMapping(QString mapping, InputDevice *device);
-    void removeDevice(InputDevice *device);
+    void removeDevice(InputDevice *device, bool saveDeviceSettings = true);
     void addInputDevice(int index, QMap<QString, int> &uniques, int &counterUniques, bool &duplicatedGamepad);
     void refreshIndexes();
+    void suspendInputCapture(QString uniqueID);
+    void resumeInputCapture();
+    bool isInputCaptureSuspended() const;
 
   private slots:
     void stop();
@@ -102,6 +112,9 @@ class InputDaemon : public QObject
 
     bool stopped;
     bool m_graphical;
+    bool m_inputCaptureSuspended;
+    bool m_allInputCaptureSuspended;
+    QSet<QString> m_suspendedCaptureUniqueIDs;
 
     SDLEventReader *eventWorker;
     QThread *sdlWorkerThread;

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -64,6 +64,9 @@ QString Joystick::getGUIDString() const
 {
     QString temp = QString();
 
+    if (m_joyhandle == nullptr)
+        return temp;
+
     SDL_JoystickGUID tempGUID = SDL_JoystickGetGUID(m_joyhandle);
     char guidString[65] = {'0'};
     SDL_JoystickGetGUIDString(tempGUID, guidString, sizeof(guidString));
@@ -142,26 +145,43 @@ QString Joystick::getUniqueIDString() const
 
 void Joystick::closeSDLDevice()
 {
+    if (controller != nullptr)
+    {
+        SDL_GameControllerClose(controller);
+        controller = nullptr;
+    }
+
     if ((m_joyhandle != nullptr) && SDL_JoystickGetAttached(m_joyhandle))
     {
         SDL_JoystickClose(m_joyhandle);
     }
+
+    m_joyhandle = nullptr;
 }
 
 int Joystick::getNumberRawButtons()
 {
+    if (m_joyhandle == nullptr)
+        return 0;
+
     int numbuttons = SDL_JoystickNumButtons(m_joyhandle);
     return numbuttons;
 }
 
 int Joystick::getNumberRawAxes()
 {
+    if (m_joyhandle == nullptr)
+        return 0;
+
     int numaxes = SDL_JoystickNumAxes(m_joyhandle);
     return numaxes;
 }
 
 int Joystick::getNumberRawHats()
 {
+    if (m_joyhandle == nullptr)
+        return 0;
+
     int numhats = SDL_JoystickNumHats(m_joyhandle);
     return numhats;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -567,8 +567,14 @@ int main(int argc, char *argv[])
     AppLaunchHelper mainAppHelper(&settings, mainWindow->getGraphicalStatus());
 
     QObject::connect(mainWindow, &MainWindow::joystickRefreshRequested, joypad_worker.data(), &InputDaemon::refresh);
+    QObject::connect(mainWindow, &MainWindow::inputCaptureSuspendRequested, joypad_worker.data(),
+                     &InputDaemon::suspendInputCapture);
+    QObject::connect(mainWindow, &MainWindow::inputCaptureResumeRequested, joypad_worker.data(),
+                     &InputDaemon::resumeInputCapture);
     QObject::connect(joypad_worker.data(), &InputDaemon::joystickRefreshed, mainWindow, &MainWindow::fillButtonsID);
     QObject::connect(joypad_worker.data(), &InputDaemon::joysticksRefreshed, mainWindow, &MainWindow::fillButtonsMap);
+    QObject::connect(joypad_worker.data(), &InputDaemon::inputCaptureResumed, mainWindow,
+                     &MainWindow::completePendingAutoProfileLoad);
 
     QObject::connect(&antimicrox, &QApplication::aboutToQuit, localServer, &LocalAntiMicroServer::close);
     QObject::connect(&antimicrox, &QApplication::aboutToQuit, mainWindow, &MainWindow::saveAppConfig);

--- a/src/sdleventreader.cpp
+++ b/src/sdleventreader.cpp
@@ -239,6 +239,18 @@ void SDLEventReader::closeDevices()
     }
 }
 
+void SDLEventReader::suspend()
+{
+    if (sdlIsOpen)
+        closeSDL();
+}
+
+void SDLEventReader::resume()
+{
+    if (!sdlIsOpen)
+        initSDL();
+}
+
 /**
  * @brief Method to block activity on the SDLEventReader object and its thread
  *   event loop.

--- a/src/sdleventreader.cpp
+++ b/src/sdleventreader.cpp
@@ -22,7 +22,7 @@
 #include "common.h"
 #include "globalvariables.h"
 #include "inputdevice.h"
-//#include "logger.h"
+// #include "logger.h"
 
 #include <SDL2/SDL.h>
 
@@ -64,11 +64,11 @@ void SDLEventReader::initSDL()
     // Passing SDL_INIT_SENSOR here triggers bug libsdl-org/SDL#4276 on windows
     // with v2.0.20. However, sensors works without in Linux and Windows so
     // skip it.
-    //#if SDL_VERSION_ATLEAST(2, 0, 14)
+    // #if SDL_VERSION_ATLEAST(2, 0, 14)
     //    SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK | SDL_INIT_SENSOR);
-    //#else
+    // #else
     SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK);
-    //#endif
+    // #endif
     SDL_JoystickEventState(SDL_ENABLE);
 
     sdlIsOpen = true;

--- a/src/sdleventreader.h
+++ b/src/sdleventreader.h
@@ -59,6 +59,8 @@ class SDLEventReader : public QObject
     void resetJoystickMap();
     void quit();
     void closeDevices();
+    void suspend();
+    void resume();
     void haltServices();
 
   private slots:


### PR DESCRIPTION
Allow selected auto profiles to temporarily release AntiMicroX's gamepad input capture so the focused application can receive controller input directly.

This is useful for games or applications that need native controller input while still allowing AntiMicroX to manage profile switching. Capture is resumed when AntiMicroX becomes focused again or when another auto profile is selected.

## Proposed changes

- Add a `releaseController` option to auto profile data and persist it for regular, default, and all-device auto profiles.
- Add UI checkboxes in auto profile edit dialogs so users can configure profiles that release controller capture instead of loading a mapping file.
- Update auto profile matching so release profiles are dispatched deliberately, including support for pending profile transitions and release-priority handling.
- Add suspend/resume lifecycle support to `InputDaemon` and `SDLEventReader` so SDL devices can be released and later reacquired cleanly.
- Thread a `saveDeviceSettings` flag through device removal paths to prevent the GUI from reading closed SDL handles during capture release.
- Add null-handle guards in `Joystick` for safer behavior after SDL handles are closed or temporarily unavailable.

## Changed files

| File | Description |
| --- | --- |
| `src/autoprofileinfo.cpp` | Initializes and serializes the new `releaseController` auto profile option. |
| `src/autoprofileinfo.h` | Adds the `releaseController` field and getter/setter API to `AutoProfileInfo`. |
| `src/autoprofilewatcher.cpp` | Loads release settings from configuration and prioritizes release profiles during auto profile matching. |
| `src/autoprofilewatcher.h` | Adds helper state needed by the updated auto profile watcher flow. |
| `src/gui/addeditautoprofiledialog.cpp` | Adds release-controller behavior to the regular auto profile edit dialog, including validation and control state updates. |
| `src/gui/addeditautoprofiledialog.h` | Declares the release-controller UI state update handler. |
| `src/gui/addeditautoprofiledialog.ui` | Adds the release controller checkbox to the auto profile edit dialog. |
| `src/gui/editalldefaultautoprofiledialog.cpp` | Adds release-controller support to the all-device default auto profile dialog. |
| `src/gui/editalldefaultautoprofiledialog.h` | Declares the default-profile release-controller UI state handler. |
| `src/gui/editalldefaultautoprofiledialog.ui` | Adds the release controller checkbox to the default auto profile dialog. |
| `src/gui/mainsettingsdialog.cpp` | Reads and writes the release-controller setting for regular, device-specific default, and all-device default auto profiles. |
| `src/gui/mainwindow.cpp` | Refactors auto profile loading into a state dispatcher that can suspend capture, resume capture, and handle pending profile transitions. |
| `src/gui/mainwindow.h` | Adds state and helper declarations for the updated auto profile release/resume flow. |
| `src/inputdaemon.cpp` | Adds suspend/resume support for SDL input capture and updates device removal handling for temporary capture release. |
| `src/inputdaemon.h` | Exposes suspend/resume APIs and tracks suspended input capture state. |
| `src/joystick.cpp` | Adds null-handle guards so joystick access remains safe after SDL handles are temporarily closed. |
| `src/main.cpp` | Registers updated types/signals needed by the new capture release flow. |
| `src/sdleventreader.cpp` | Adds SDL reader suspend/resume support and applies clang-format cleanup. |
| `src/sdleventreader.h` | Exposes SDL event reader suspend/resume APIs. |

## AI collaboration

This change was developed with AI assistance and reviewed through:

| Tool | Role |
| --- | --- |
| GPT-5.5 | Implementation assistance and PR description drafting. |
| Claude Opus 4.6 | Review feedback and validation support. |

## Behavior

When a matched auto profile has controller release enabled, AntiMicroX stops capturing the affected controller so the currently focused application can use it directly. When AntiMicroX regains focus, or a different auto profile becomes active, input capture is restored and normal profile behavior continues.

## Motivation

I use AntiMicroX to map a Switch Pro Controller for keyboard-controlled games. However, when switching to RetroArch, the controller is detected but its input does not work while AntiMicroX is still running. I have to close AntiMicroX before RetroArch responds to the controller.

This change allows an auto profile to release controller capture for applications like RetroArch, so the controller can be passed through directly without closing AntiMicroX. I think this should be useful for other users who switch between keyboard-mapped games and applications that need native controller input.